### PR TITLE
dotfiles/vim: use jq to format JSON files

### DIFF
--- a/dotfiles/editor/vim/ftplugin/json.vim
+++ b/dotfiles/editor/vim/ftplugin/json.vim
@@ -1,2 +1,2 @@
-let b:ale_fixers = ['prettier'] " ['jq']
+let b:ale_fixers = ['jq'] " ['prettier']
 let g:ale_fix_on_save = 1


### PR DESCRIPTION
Prettier was used previously due to conflicts on teammates' machines.