### PR TITLE
chrome: hide Twitter promoted tweets

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,8 +1,21 @@
 {
   "content_scripts": [
-    { "matches": ["https://lite.cnn.io/*"], "css": ["litecnn.css"] },
-    { "matches": ["https://theathletic.com/*"], "css": ["theathletic.css"] },
-    { "matches": ["https://twitter.com/*"], "css": ["twitter.css"] }
+    {
+      "matches": [
+        "https://lite.cnn.io/*"
+      ],
+      "css": [
+        "litecnn.css"
+      ]
+    },
+    {
+      "matches": [
+        "https://twitter.com/*"
+      ],
+      "css": [
+        "twitter.css"
+      ]
+    }
   ],
   "description": "User styles",
   "manifest_version": 2,

--- a/chrome/twitter.css
+++ b/chrome/twitter.css
@@ -1,8 +1,3 @@
-.Footer,
-.ProfileCanopy,
-.ProfileSidebar,
-.Trends,
-.dashboard-right,
-.promoted-tweet {
+div[data-testid="placementTracking"] > article {
   display: none;
 }


### PR DESCRIPTION
Remove user script for The Athletic to make it compile.
Run manifest through `jq` (formatting).