### PR TITLE
dotfiles/vim: use coc.vim and ALE together

### DIFF
--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -2,28 +2,19 @@
   "coc.preferences.formatOnSaveFiletypes": [
     "css",
     "javascript",
-    "json",
-    "markdown",
+    "javascriptreact",
     "ruby",
     "scss",
     "typescript",
-    "yaml"
+    "typescriptreact"
   ],
   "languageserver": {
     "golang": {
       "command": "gopls",
-      "filetypes": [
-        "go"
-      ],
-      "rootPatterns": [
-        "go.mod",
-        ".vim/",
-        ".git/"
-      ]
+      "filetypes": ["go"],
+      "rootPatterns": ["go.mod", ".vim/", ".git/"]
     }
   },
-  "solargraph": {
-    "commandPath": "/Users/croaky/.asdf/shims/solargraph"
-  },
+  "solargraph.commandPath": "/Users/croaky/.asdf/shims/solargraph",
   "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
 }

--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -23,8 +23,7 @@
     }
   },
   "solargraph": {
-    "bundlerPath": "/Users/croaky/.asdf/shims/bundle",
-    "useBundler": true
+    "commandPath": "/Users/croaky/.asdf/shims/solargraph"
   },
   "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
 }

--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -1,0 +1,30 @@
+{
+  "coc.preferences.formatOnSaveFiletypes": [
+    "css",
+    "javascript",
+    "json",
+    "markdown",
+    "ruby",
+    "scss",
+    "typescript",
+    "yaml"
+  ],
+  "languageserver": {
+    "golang": {
+      "command": "gopls",
+      "filetypes": [
+        "go"
+      ],
+      "rootPatterns": [
+        "go.mod",
+        ".vim/",
+        ".git/"
+      ]
+    }
+  },
+  "solargraph": {
+    "bundlerPath": "/Users/croaky/.asdf/shims/bundle",
+    "useBundler": true
+  },
+  "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
+}

--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -1,13 +1,4 @@
 {
-  "coc.preferences.formatOnSaveFiletypes": [
-    "css",
-    "javascript",
-    "javascriptreact",
-    "ruby",
-    "scss",
-    "typescript",
-    "typescriptreact"
-  ],
   "languageserver": {
     "golang": {
       "command": "gopls",

--- a/dotfiles/editor/vim/ftplugin/css.vim
+++ b/dotfiles/editor/vim/ftplugin/css.vim
@@ -1,7 +1,1 @@
 setlocal iskeyword+=-
-
-" Auto-fix w/ Prettier or stylelint?
-" TODO: add coc.vim config
-
-" Lint w/ Prettier or stylelint?
-" TODO: add coc.vim config

--- a/dotfiles/editor/vim/ftplugin/css.vim
+++ b/dotfiles/editor/vim/ftplugin/css.vim
@@ -1,1 +1,8 @@
 setlocal iskeyword+=-
+
+" Auto-fix?
+" let b:ale_fixers = ['prettier']
+" let g:ale_fix_on_save = 1
+
+" Lint?
+" let b:ale_linters = ['prettier']

--- a/dotfiles/editor/vim/ftplugin/go.vim
+++ b/dotfiles/editor/vim/ftplugin/go.vim
@@ -2,8 +2,10 @@
 let g:go_fmt_command = 'goimportslocal'
 let g:go_rename_command = 'gopls'
 
-" disable vim-go :GoDef shortcut, use coc.vim's gd instead
-" let g:go_def_mapping_enabled = 0
+" Auto-fix handled by go.vim
+
+" Lint
+let b:ale_linters = ['gopls']
 
 setlocal listchars=tab:\ \ ,trail:·,nbsp:·
 setlocal noexpandtab

--- a/dotfiles/editor/vim/ftplugin/go.vim
+++ b/dotfiles/editor/vim/ftplugin/go.vim
@@ -3,7 +3,7 @@ let g:go_fmt_command = 'goimportslocal'
 let g:go_rename_command = 'gopls'
 
 " disable vim-go :GoDef shortcut, use coc.vim's gd instead
-let g:go_def_mapping_enabled = 0
+" let g:go_def_mapping_enabled = 0
 
 setlocal listchars=tab:\ \ ,trail:·,nbsp:·
 setlocal noexpandtab

--- a/dotfiles/editor/vim/ftplugin/go.vim
+++ b/dotfiles/editor/vim/ftplugin/go.vim
@@ -2,8 +2,8 @@
 let g:go_fmt_command = 'goimportslocal'
 let g:go_rename_command = 'gopls'
 
-" Lint https://octetz.com/docs/2019/2019-04-24-vim-as-a-go-ide/
-" TODO: coc.vim
+" disable vim-go :GoDef shortcut, use coc.vim's gd instead
+let g:go_def_mapping_enabled = 0
 
 setlocal listchars=tab:\ \ ,trail:·,nbsp:·
 setlocal noexpandtab

--- a/dotfiles/editor/vim/ftplugin/javascript.vim
+++ b/dotfiles/editor/vim/ftplugin/javascript.vim
@@ -1,5 +1,2 @@
-" Auto-fix w/ Prettier
-" TODO: add coc.vim config
-
 let g:javascript_plugin_flow = 1
 let g:jsx_ext_required = 0

--- a/dotfiles/editor/vim/ftplugin/javascript.vim
+++ b/dotfiles/editor/vim/ftplugin/javascript.vim
@@ -1,2 +1,9 @@
 let g:javascript_plugin_flow = 1
 let g:jsx_ext_required = 0
+
+" Auto-fix
+let b:ale_fixers = ['prettier']
+let g:ale_fix_on_save = 1
+
+" Lint
+let b:ale_linters = ['prettier']

--- a/dotfiles/editor/vim/ftplugin/json.vim
+++ b/dotfiles/editor/vim/ftplugin/json.vim
@@ -1,2 +1,3 @@
-" Auto-fix w/ jq or Prettier?
-" TODO: add coc.vim config
+" Auto-fix
+let b:ale_fixers = ['prettier'] " ['jq']
+let g:ale_fix_on_save = 1

--- a/dotfiles/editor/vim/ftplugin/ruby.vim
+++ b/dotfiles/editor/vim/ftplugin/ruby.vim
@@ -1,10 +1,11 @@
 " TODO: try sorbet https://sorbet.org/
 
-" Auto-fix w/ standardrb?
-" TODO: add coc.vim config
+" Auto-fix
+let b:ale_fixers = ['standardrb'] " 'rubocop'
+let g:ale_fix_on_save = 1
 
-" Lint w/ standardrb?
-" TODO: add coc.vim config
+" Lint
+let b:ale_linters = ['standardrb'] " 'rubocop'
 
 " https://github.com/testdouble/standard/wiki/IDE:-vim
 let g:ruby_indent_assignment_style = 'variable'

--- a/dotfiles/editor/vim/ftplugin/scss.vim
+++ b/dotfiles/editor/vim/ftplugin/scss.vim
@@ -1,7 +1,1 @@
 setlocal iskeyword+=-
-
-" Auto-fix w/ Prettier or stylelint?
-" TODO: coc.vim
-
-" Lint w/ Prettier or stylelint?
-" TODO: coc.vim

--- a/dotfiles/editor/vim/ftplugin/typescript.vim
+++ b/dotfiles/editor/vim/ftplugin/typescript.vim
@@ -1,8 +1,6 @@
-setlocal iskeyword+=-
-
 " Auto-fix
 let b:ale_fixers = ['prettier']
 let g:ale_fix_on_save = 1
 
 " Lint
-let b:ale_linters = ['prettier']
+let b:ale_linters = ['tsserver']

--- a/dotfiles/editor/vim/ftplugin/typescript.vim
+++ b/dotfiles/editor/vim/ftplugin/typescript.vim
@@ -1,5 +1,0 @@
-" Fix w/ Prettier
-" TODO: add coc.vim config
-
-" Lint w/ TSLint or tsserver
-" TODO: add coc.vim config

--- a/dotfiles/editor/vim/ftplugin/yaml.vim
+++ b/dotfiles/editor/vim/ftplugin/yaml.vim
@@ -1,8 +1,3 @@
-setlocal iskeyword+=-
-
 " Auto-fix
 let b:ale_fixers = ['prettier']
 let g:ale_fix_on_save = 1
-
-" Lint
-let b:ale_linters = ['prettier']

--- a/dotfiles/editor/vim/ftplugin/yaml.vim
+++ b/dotfiles/editor/vim/ftplugin/yaml.vim
@@ -1,2 +1,0 @@
-" Auto-fix w/ Prettier
-" TODO: coc.vim

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -95,6 +95,16 @@ augroup lastcursorposition
     \ endif
 augroup END
 
+" https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions
+let g:coc_global_extensions = [
+  \ 'coc-css',
+  \ 'coc-elixir',
+  \ 'coc-git',
+  \ 'coc-html',
+  \ 'coc-prettier',
+  \ 'coc-tsserver'
+  \ ]
+
 " Jump to definition
 nmap <silent> gd <Plug>(coc-definition)
 nmap <silent> gy <Plug>(coc-type-definition)
@@ -211,17 +221,18 @@ hi VisualNOS      ctermfg=250 ctermbg=24  cterm=NONE
 hi gitCommitDiff  ctermfg=250 cterm=NONE
 
 " Pink
-hi CocErrorSign ctermfg=161 cterm=NONE ctermbg=250
-hi DiffDelete   ctermfg=161 cterm=NONE
-hi Directory    ctermfg=161 cterm=NONE
-hi Function     ctermfg=161
-hi ModeMsg      ctermfg=161 cterm=NONE
-hi MoreMsg      ctermfg=161 cterm=NONE
-hi String       ctermfg=161 cterm=NONE
-hi Title        ctermfg=161 cterm=NONE
-hi WarningMsg   ctermfg=161 cterm=NONE
-hi diffRemoved  ctermfg=161 cterm=NONE
-hi rubySymbol   ctermfg=161 cterm=NONE
+hi CocErrorSign   ctermfg=161 cterm=NONE ctermbg=250
+hi CocWarningSign ctermfg=161 cterm=NONE ctermbg=250
+hi DiffDelete     ctermfg=161 cterm=NONE
+hi Directory      ctermfg=161 cterm=NONE
+hi Function       ctermfg=161
+hi ModeMsg        ctermfg=161 cterm=NONE
+hi MoreMsg        ctermfg=161 cterm=NONE
+hi String         ctermfg=161 cterm=NONE
+hi Title          ctermfg=161 cterm=NONE
+hi WarningMsg     ctermfg=161 cterm=NONE
+hi diffRemoved    ctermfg=161 cterm=NONE
+hi rubySymbol     ctermfg=161 cterm=NONE
 
 " Turquoise
 hi Constant       ctermfg=30  cterm=NONE

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -3,12 +3,14 @@ let mapleader = " "   " Spacebar
 set autoindent
 set autowrite         " Automatically :write before running commands
 set backspace=2       " Backspace deletes like most programs in insert mode
+set cmdheight=2
 set colorcolumn=+1
 set complete+=kspell  " Include spellfile in completion results
 set diffopt+=vertical " Always use vertical diffs
 set encoding=utf-8
 set expandtab
 set exrc              " http://andrew.stwrt.ca/posts/project-specific-vimrc/
+set hidden            " TextEdit might fail if hidden is not set
 set history=50
 set incsearch
 set laststatus=2      " Always display status line
@@ -24,11 +26,14 @@ set numberwidth=5
 set ruler             " Ahow cursor position all the time
 set shiftround
 set shiftwidth=2
+set shortmess+=c      " Don't pass messages to |ins-completion-menu|
 set showcmd           " Display incomplete commands
+set signcolumn=yes
 set splitbelow
 set splitright
 set tabstop=2
 set textwidth=80
+set updatetime=300
 
 if &compatible
   set nocompatible
@@ -41,6 +46,9 @@ call plug#begin('~/.vim/plugged')
   " Automatic, no commands
   Plug 'pbrisbin/vim-mkdir' " auto-create non-existent dir on save
   Plug 'tpope/vim-endwise'  " auto-add end in Ruby, other langs
+
+  " Language Server Protocol
+  Plug 'neoclide/coc.nvim', { 'branch': 'release' }
 
   " Movement
   Plug 'tpope/vim-projectionist' " :help projectionist, .projections.json, :A
@@ -87,11 +95,37 @@ augroup lastcursorposition
     \ endif
 augroup END
 
-" Lint
-" TODO: add coc.vim config
+" Jump to definition
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gr <Plug>(coc-references)
 
 " Tab complete
-" TODO: add coc.vim config
+inoremap <silent><expr> <TAB>
+  \ pumvisible() ? "\<C-n>" :
+  \ <SID>check_back_space() ? "\<TAB>" :
+  \ coc#refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+
+function! s:check_back_space() abort
+  let col = col('.') - 1
+  return !col || getline('.')[col - 1]  =~# '\s'
+endfunction
+
+" Docs
+nnoremap <silent> K :call <SID>show_documentation()<CR>
+
+function! s:show_documentation()
+  if (index(['vim','help'], &filetype) >= 0)
+    execute 'h '.expand('<cword>')
+  else
+    call CocAction('doHover')
+  endif
+endfunction
+
+" :Format current buffer
+command! -nargs=0 Format :call CocAction('format')
 
 " Disable spelling by default, enable per-filetype
 autocmd BufRead setlocal nospell
@@ -177,16 +211,17 @@ hi VisualNOS      ctermfg=250 ctermbg=24  cterm=NONE
 hi gitCommitDiff  ctermfg=250 cterm=NONE
 
 " Pink
-hi DiffDelete     ctermfg=161 cterm=NONE
-hi Directory      ctermfg=161 cterm=NONE
-hi Function       ctermfg=161
-hi ModeMsg        ctermfg=161 cterm=NONE
-hi MoreMsg        ctermfg=161 cterm=NONE
-hi String         ctermfg=161 cterm=NONE
-hi Title          ctermfg=161 cterm=NONE
-hi WarningMsg     ctermfg=161 cterm=NONE
-hi diffRemoved    ctermfg=161 cterm=NONE
-hi rubySymbol     ctermfg=161 cterm=NONE
+hi CocErrorSign ctermfg=161 cterm=NONE ctermbg=250
+hi DiffDelete   ctermfg=161 cterm=NONE
+hi Directory    ctermfg=161 cterm=NONE
+hi Function     ctermfg=161
+hi ModeMsg      ctermfg=161 cterm=NONE
+hi MoreMsg      ctermfg=161 cterm=NONE
+hi String       ctermfg=161 cterm=NONE
+hi Title        ctermfg=161 cterm=NONE
+hi WarningMsg   ctermfg=161 cterm=NONE
+hi diffRemoved  ctermfg=161 cterm=NONE
+hi rubySymbol   ctermfg=161 cterm=NONE
 
 " Turquoise
 hi Constant       ctermfg=30  cterm=NONE

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -44,6 +44,7 @@ let g:plug_window='enew'
 
 call plug#begin('~/.vim/plugged')
   " Automatic, no commands
+  Plug 'dense-analysis/ale' " :help ale
   Plug 'pbrisbin/vim-mkdir' " auto-create non-existent dir on save
   Plug 'tpope/vim-endwise'  " auto-add end in Ruby, other langs
 
@@ -95,6 +96,15 @@ augroup lastcursorposition
     \ endif
 augroup END
 
+" Lint with ALE
+augroup ale
+  autocmd!
+
+  autocmd VimEnter *
+    \ let g:ale_lint_on_enter = 1 |
+    \ let g:ale_lint_on_text_changed = 0
+augroup END
+
 " https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions
 let g:coc_global_extensions = [
   \ 'coc-css',
@@ -111,7 +121,7 @@ nmap <silent> gy <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references)
 
-" Tab complete
+" Tab complete with COC
 inoremap <silent><expr> <TAB>
   \ pumvisible() ? "\<C-n>" :
   \ <SID>check_back_space() ? "\<TAB>" :
@@ -133,9 +143,6 @@ function! s:show_documentation()
     call CocAction('doHover')
   endif
 endfunction
-
-" :Format current buffer
-command! -nargs=0 Format :call CocAction('format')
 
 " Disable spelling by default, enable per-filetype
 autocmd BufRead setlocal nospell

--- a/laptop.sh
+++ b/laptop.sh
@@ -101,6 +101,7 @@ esac
   mkdir -p "$HOME/.vim/syntax"
   (
     cd editor/vim
+    ln -sf "$PWD/coc-settings.json" "$HOME/.vim/coc-settings.json"
     for f in {ftdetect,ftplugin,syntax}/*; do
       ln -sf "$PWD/$f" "$HOME/.vim/$f"
     done


### PR DESCRIPTION
After testing Ruby, TypeScript, React, Go, JSON, and Markdown,
coc.vim feels good for jump to definition and auto-completion
and ALE feels good for linting and auto-fixing (auto-formatting).