### PR TITLE
all: fixes for Catalina on new MacBook Pro

### DIFF
--- a/dotfiles/shell/tmux.conf
+++ b/dotfiles/shell/tmux.conf
@@ -1,3 +1,6 @@
+# set Homebrew version of zsh as shell
+set -g default-shell /usr/local/bin/zsh
+
 # act like GNU screen
 unbind C-b
 set -g prefix C-a

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -80,7 +80,7 @@ compinit
 
 # Set environment variables for monorepos
 export LAPTOP="$HOME/laptop"
-export BLOG="$HOME/src/github.com/croaky/blog"
+export BLOG="$HOME/blog"
 
 # Set environment variable for localhost TLS certificate authority file
 # https://github.com/FiloSottile/mkcert


### PR DESCRIPTION
Ran into a few "first run" issues for laptop.sh.

zsh is now the default shell starting with macOS Catalina.
https://support.apple.com/en-us/HT208050

This appears to have caused some new permissions conflicts
with the Homebrew-installed version.
Keep using the Homebrew-installed version for frequent updates.

Set the Homebrew version of zsh as default shell in tmux
to silence a warning when creating a new session.

Remove a reference to `$LAPTOP`. I didn't read the README (ha!)
and so didn't have the env var set before running the script.

Ensure asdf is on `$PATH` before invoking.

Run vim-plug commands last because
coc.vim may expect programming languages like `node` to be available.