### PR TITLE
dotfiles/vim: auto-install coc-solargraph

### DIFF
--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -112,6 +112,7 @@ let g:coc_global_extensions = [
   \ 'coc-git',
   \ 'coc-html',
   \ 'coc-prettier',
+  \ 'coc-solargraph',
   \ 'coc-tsserver'
   \ ]
 


### PR DESCRIPTION
If coc-solargraph is not installed on Vim load for Ruby,
install it. Also acts as documentation about what my env needs.