### PR TITLE
dotfiles/vim/coc: don't check gem version

### DIFF
--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -6,6 +6,7 @@
       "rootPatterns": ["go.mod", ".vim/", ".git/"]
     }
   },
-  "solargraph.commandPath": "/Users/croaky/.asdf/shims/solargraph",
-  "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
+  "solargraph.checkGemVersion": false,
+  "solargraph.commandPath": "/Users/dcroak/.asdf/shims/solargraph",
+  "tsserver.npm": "/Users/dcroak/.asdf/shims/npm"
 }


### PR DESCRIPTION
This pop-up is aggressive and sometimes the latest version has bugs.