### PR TITLE
Use open instead of hub CLI

### DIFF
--- a/bin/hubopen
+++ b/bin/hubopen
@@ -2,12 +2,8 @@
 #
 # Open a file in the current repo, branch, and subdir on GitHub.
 
-if ! command -v hub >/dev/null; then
-  if command -v brew >/dev/null; then
-    brew install hub
-  fi
-fi
-
+url="$(git config --get remote.origin.url)"
 branch="$(git rev-parse --abbrev-ref HEAD)"
 subdir="$(git rev-parse --show-prefix)"
-hub browse -- blob/"$branch"/"$subdir"/"$1"
+
+open "${url%.git}/blob/$branch$subdir/$1"


### PR DESCRIPTION
I'm not using `hub` anymore, have replaced it with `gh`.
`gh` doesn't have the ability to open a particular file yet.
Use `open` instead.

Depends on the `origin` remote using `https` instead of SSH.