### PR TITLE
bin/git: use exact match

### DIFF
--- a/bin/git-post-land
+++ b/bin/git-post-land
@@ -4,7 +4,7 @@ set -e
 
 main="master"
 
-if git branch | grep -Fq "main"; then
+if git branch | grep -Fq "^main$"; then
   main="main"
 fi
 

--- a/bin/git-up
+++ b/bin/git-up
@@ -4,7 +4,7 @@ set -e
 
 main="master"
 
-if git branch | grep -Fq "main"; then
+if git branch | grep -Fq "^main$"; then
   main="main"
 fi
 


### PR DESCRIPTION
Avoid false positives for branch names like `romaine`.