### PR TITLE
dotfiles/shell: set up window splits

### DIFF
--- a/dotfiles/shell/kitty.conf
+++ b/dotfiles/shell/kitty.conf
@@ -33,3 +33,8 @@ map super+7 goto_tab 7
 map super+8 goto_tab 8
 map super+9 goto_tab 9
 map super+0 goto_tab 10
+
+# layouts
+# ctrl+shift+enter to add split
+# ctrl+shift+] and ctrl+shift+[ to navigate between splits
+enabled_layouts horizontal


### PR DESCRIPTION
I have been wanting side-by-side windows:

* editor
* server log
* command line

Kitty supports this with the `enabled_layouts horizontal` setting.

https://sw.kovidgoyal.net/kitty/#windows