### PR TITLE
dotfiles/vim/svelte: configure tab completion

### DIFF
--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -71,7 +71,7 @@ call plug#begin('~/.vim/plugged')
   " Markdown
   Plug 'junegunn/vim-easy-align' " <Leader>| align table
 
-  " TypeScript, React, GraphQL
+  " Frontend
   Plug 'evanleck/vim-svelte'
   Plug 'jparise/vim-graphql'
   Plug 'leafgarland/typescript-vim'
@@ -113,6 +113,7 @@ let g:coc_global_extensions = [
   \ 'coc-html',
   \ 'coc-prettier',
   \ 'coc-solargraph',
+  \ 'coc-svelte',
   \ 'coc-tsserver'
   \ ]
 


### PR DESCRIPTION
Svelte now supports TypeScript, including tab completion.

https://svelte.dev/blog/svelte-and-typescript