### PR TITLE
dotfiles/vim: configure coc-go

### DIFF
--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -110,6 +110,7 @@ augroup END
 let g:coc_global_extensions = [
   \ 'coc-css',
   \ 'coc-git',
+  \ 'coc-go',
   \ 'coc-html',
   \ 'coc-prettier',
   \ 'coc-svelte',


### PR DESCRIPTION
Autocompletion for Go via `gopls` Language Server Protocol.