### PR TITLE
laptop.sh: update for gh 1.0

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -34,15 +34,14 @@ fi
 brew analytics off
 brew update-reset
 brew bundle --no-lock --file=- <<EOF
-tap "github/gh"
 tap "heroku/brew"
 tap "homebrew/services"
 
 brew "awscli"
 brew "exercism"
 brew "fzf"
+brew "gh"
 brew "git"
-brew "github/gh/gh"
 brew "heroku"
 brew "jq"
 brew "libyaml"


### PR DESCRIPTION
The install command should be brew "gh" now.
The formula is not managed in the `github/gh` Homebrew tap anymore.
It is managed in Homebrew core: Homebrew/homebrew-core#61231

I also ran:

```
brew uninstall github/gh/gh
brew untap github/gh
brew update
brew install gh
```