### PR TITLE
dotfiles/git: use date format for "git lt" alias

### DIFF
--- a/dotfiles/git/gitconfig
+++ b/dotfiles/git/gitconfig
@@ -33,7 +33,7 @@
   cmd = vimdiff -f $LOCAL $MERGED $REMOTE
 [pretty]
   basic = format:%Cred%h%Creset %s%Creset
-  time = format:%Cred%h%Creset %s %Cgreen(%cr)%Creset
+  time = format:%Cred%h%Creset %C(bold blue)%cs%Creset %s%Creset
   author = format:%Cred%h%Creset %s %C(bold blue)%an%Creset
   timeauthor = format:%Cred%h%Creset %s %Cgreen(%cr) %C(bold blue)%an%Creset
 [push]


### PR DESCRIPTION
Example output:

```
62d5310 2020-09-25 dotfiles/git: use date format for "git lt" alias
69f6d62 2020-09-25 dotfiles/vim/sql: add <Leader>v to run SQL file w/ variable
560d2fd 2020-09-18 laptop.sh: update for gh 1.0
545be99 2020-08-25 dotfiles/vim: configure coc-go
83fa1db 2020-08-22 laptop.sh: install Deno
ca13999 2020-08-22 laptop.sh: upgrade Node to 14.8.0
7a0c065 2020-08-15 dotfiles/shell: add $TODO monorepo
77e51ab 2020-08-15 dotfiles/vim: disable solargraph
e90fe8d 2020-08-15 laptop.sh: upgrade Go to 1.15
f756d11 2020-08-03 laptop.sh: install pgformatter
0ae64ca 2020-08-03 dotfiles/vim/sql: use pgformatter
7efa5de 2020-08-03 dotfiles/git: init new repos with main default branch
```