### PR TITLE
dotfiles/editor/coc: use home laptop username

### DIFF
--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -6,5 +6,5 @@
       "rootPatterns": ["go.mod", ".vim/", ".git/"]
     }
   },
-  "tsserver.npm": "/Users/dcroak/.asdf/shims/npm"
+  "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
 }


### PR DESCRIPTION
I churn on my laptop setup more often on my home machine
where I play with different tools and setups.

It's a little awkward to always workaround the diff here.