### PR TITLE
all: improve Go environment

### DIFF
--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -1,10 +1,3 @@
 {
-  "languageserver": {
-    "golang": {
-      "command": "gopls",
-      "filetypes": ["go"],
-      "rootPatterns": ["go.mod", ".vim/", ".git/"]
-    }
-  },
   "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
 }

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -183,75 +183,73 @@ if version > 580
   endif
 endif
 
-" Show syntax groups under cursor
-map <silent> zs :for id in synstack(line("."), col("."))<bar>
-  \ echo synIDattr(id, "name").' '<bar> execute 'echohl' synIDattr(synIDtrans(id), "name") <bar> echon synIDattr(synIDtrans(id), "name") <bar> echohl None <bar>
-  \ endfor<CR>
+" Show all syntax groups
+" :so $VIMRUNTIME/syntax/hitest.vim
 
 " Black
-hi IncSearch      ctermfg=16  ctermbg=189 cterm=NONE
+hi IncSearch      ctermfg=16  ctermbg=189
 hi Label          ctermfg=16
-hi MatchParen     ctermfg=16  ctermbg=189 cterm=NONE
-hi Normal         ctermfg=16  ctermbg=231 cterm=NONE
-hi PmenuSel       ctermfg=16  ctermbg=189 cterm=NONE
-hi Search         ctermfg=16  ctermbg=189 cterm=NONE
+hi MatchParen     ctermfg=16  ctermbg=189
+hi Normal         ctermfg=16  ctermbg=231
+hi Pmenu          ctermfg=16  ctermbg=231
+hi PmenuSbar      ctermfg=16  ctermbg=231
+hi PmenuThumb     ctermfg=16  ctermbg=231
+hi Search         ctermfg=16  ctermbg=189
 hi Statement      ctermfg=16
 hi StorageClass   ctermfg=16
 hi Structure      ctermfg=16
 hi TypeDef        ctermfg=16
-hi Underlined     ctermfg=16  cterm=UNDERLINE
+hi Underlined     ctermfg=16 cterm=NONE
 hi rubyDefine     ctermfg=16
 hi rubyMacro      ctermfg=16
 hi rubyValidation ctermfg=16
 
 " Light gray
-hi ColorColumn    ctermbg=250 cterm=NONE
-hi Comment        ctermfg=250 cterm=NONE
-hi Cursor         ctermfg=250 ctermbg=238 cterm=NONE
-hi CursorColumn   ctermbg=250 cterm=NONE
-hi CursorLine     ctermbg=250 cterm=NONE
-hi CursorLineNr   ctermfg=250 ctermbg=253 cterm=NONE
-hi Error          ctermfg=250 ctermbg=196 cterm=NONE
-hi Folded         ctermfg=250 ctermbg=255 cterm=NONE
-hi Ignore         ctermfg=250 cterm=NONE
-hi LineNr         ctermfg=250 ctermbg=255 cterm=NONE
-hi NonText        ctermfg=250 ctermbg=255 cterm=NONE
-hi Pmenu          ctermfg=250 ctermbg=244
-hi PmenuSbar      ctermfg=250 ctermbg=16  cterm=NONE
-hi PmenuThumb     ctermfg=250 ctermbg=248 cterm=NONE
+hi Comment        ctermfg=250
+hi Cursor         ctermfg=250 ctermbg=238
+hi CursorLineNr   ctermfg=250 ctermbg=253
+hi Error          ctermfg=250 ctermbg=196
+hi Folded         ctermfg=250 ctermbg=255
+hi Ignore         ctermfg=250
+hi LineNr         ctermfg=250 ctermbg=255
+hi NonText        ctermfg=250 ctermbg=255
+hi PmenuSel       ctermfg=250 ctermbg=238
 hi PreProc        ctermfg=250
-hi SpecialKey     ctermfg=250 ctermbg=196 cterm=NONE
+hi SpecialKey     ctermfg=250 ctermbg=196
 hi StatusLine     ctermfg=250 ctermbg=255
-hi StatusLineNC   ctermfg=250 ctermbg=255 cterm=NONE
-hi TabLine        ctermfg=250 ctermbg=253 cterm=NONE
-hi TabLineFill    ctermfg=250 ctermbg=253 cterm=NONE
+hi StatusLineNC   ctermfg=250 ctermbg=255
+hi TabLine        ctermfg=250 ctermbg=253
+hi TabLineFill    ctermfg=250 ctermbg=253
 hi TabLineSel     ctermfg=250
 hi Todo           ctermfg=250 ctermbg=88
-hi VertSplit      ctermfg=250 ctermbg=250 cterm=NONE
-hi Visual         ctermfg=250 ctermbg=61  cterm=NONE
-hi VisualNOS      ctermfg=250 ctermbg=24  cterm=NONE
-hi gitCommitDiff  ctermfg=250 cterm=NONE
+hi VertSplit      ctermfg=250 ctermbg=250
+hi Visual         ctermfg=250 ctermbg=61
+hi VisualNOS      ctermfg=250 ctermbg=24
+hi gitCommitDiff  ctermfg=250
 
 " Pink
-hi CocErrorSign   ctermfg=161 cterm=NONE ctermbg=250
-hi CocWarningSign ctermfg=161 cterm=NONE ctermbg=250
-hi DiffDelete     ctermfg=161 cterm=NONE
-hi Directory      ctermfg=161 cterm=NONE
+hi CocErrorSign   ctermfg=161
+hi CocWarningSign ctermfg=161
+hi DiffDelete     ctermfg=161
+hi Directory      ctermfg=161
+hi ErrorMsg       ctermfg=161
 hi Function       ctermfg=161
-hi ModeMsg        ctermfg=161 cterm=NONE
-hi MoreMsg        ctermfg=161 cterm=NONE
-hi String         ctermfg=161 cterm=NONE
-hi Title          ctermfg=161 cterm=NONE
-hi WarningMsg     ctermfg=161 cterm=NONE
-hi diffRemoved    ctermfg=161 cterm=NONE
-hi rubySymbol     ctermfg=161 cterm=NONE
+hi ModeMsg        ctermfg=161
+hi MoreMsg        ctermfg=161
+hi SpecialKey     ctermfg=161
+hi String         ctermfg=161
+hi Title          ctermfg=161
+hi Todo           ctermfg=161
+hi WarningMsg     ctermfg=161
+hi diffRemoved    ctermfg=161
+hi rubySymbol     ctermfg=161
 
 " Turquoise
-hi Constant       ctermfg=30  cterm=NONE
-hi DiffAdd        ctermfg=30  ctermbg=194 cterm=NONE
-hi Identifier     ctermfg=30  cterm=NONE
-hi Number         ctermfg=30  cterm=NONE
+hi Constant       ctermfg=30
+hi DiffAdd        ctermfg=30 ctermbg=194
+hi Identifier     ctermfg=30
+hi Number         ctermfg=30
 hi Special        ctermfg=30
 hi Type           ctermfg=30
-hi WildMenu       ctermfg=30 ctermbg=60  cterm=NONE
-hi diffAdded      ctermfg=30  cterm=NONE
+hi WildMenu       ctermfg=30 ctermbg=60
+hi diffAdded      ctermfg=30

--- a/laptop.sh
+++ b/laptop.sh
@@ -137,7 +137,7 @@ esac
 )
 
 # Go
-gover="1.15"
+gover="1.15.4"
 if ! go version | grep -Fq "$gover"; then
   sudo rm -rf /usr/local/go
   curl "https://dl.google.com/go/go$gover.darwin-amd64.tar.gz" | \


### PR DESCRIPTION
Language: upgrade to Go 1.15.4.
Format: Improve menu colors, use less underlining.
Autocompletion: don't use COC; it depends on Node
and creates duplicates in autocomplete list.