### PR TITLE
laptop.sh: update Homebrew install command

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -27,7 +27,7 @@ else
 fi
 
 if ! command -v brew >/dev/null; then
-  curl -fsS 'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
   export PATH="/usr/local/bin:$PATH"
 fi
 


### PR DESCRIPTION
From https://raw.githubusercontent.com/Homebrew/install/master/install

```

STDERR.print <<EOS
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

EOS

Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
```