### PR TITLE
dotfiles/shell/bat: add

### DIFF
--- a/dotfiles/shell/bat
+++ b/dotfiles/shell/bat
@@ -1,0 +1,1 @@
+--theme="GitHub"

--- a/laptop.sh
+++ b/laptop.sh
@@ -38,6 +38,7 @@ tap "heroku/brew"
 tap "homebrew/services"
 
 brew "awscli"
+brew "bat"
 brew "exercism"
 brew "fzf"
 brew "gh"
@@ -127,6 +128,9 @@ esac
 
   mkdir -p "$HOME/.ssh"
   ln -sf "$PWD/shell/ssh" "$HOME/.ssh/config"
+
+  mkdir -p "$HOME/.config/bat"
+  ln -sf "$PWD/shell/bat" "$HOME/.config/bat/config"
 
   ln -sf "$PWD/shell/curlrc" "$HOME/.curlrc"
   ln -sf "$PWD/shell/hushlogin" "$HOME/.hushlogin"


### PR DESCRIPTION
Install `bat`, a syntax-highlighted `cat`.
`fzf` uses `bat`, if present, in its file previews.
Set the theme to GitHub, which is closest to my color scheme.
Look into customizing it further later.