### PR TITLE
dotfiles/vim/svelte: adjust for Tailwind

### DIFF
--- a/dotfiles/editor/vim/ftplugin/svelte.vim
+++ b/dotfiles/editor/vim/ftplugin/svelte.vim
@@ -1,7 +1,6 @@
-" let g:svelte_preprocessors = ['typescript']
+let g:svelte_preprocessors = ['typescript', 'postcss']
 
 " Auto-fix
+let b:ale_fixers = ['prettier']
 let g:ale_fix_on_save = 1
-
-" Lint
-" let b:ale_linters = ['typescript']
+let g:ale_javascript_prettier_options = '--plugin-search-dir=.'


### PR DESCRIPTION
I've been experimenting with a frontend stack of
Svelte, Tailwind, TypeScript, and Svite based on
https://codechips.me/svelte-postcss-and-typescript-with-svite/

It's felt pretty good, committing the Vim changes.

Add `postcss` preprocessor for Svelte.
Remove commented-out code.
Add Prettier option to get "fix on save" working.