### PR TITLE
bin/kill-pid-on-port: add

### DIFF
--- a/bin/kill-pid-on-port
+++ b/bin/kill-pid-on-port
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Kill processes listening on a given port.
+#
+# kill-pid-on-port 3000
+
+lsof -n -i :"$1" | grep LISTEN | awk '{ print $2 }' | xargs kill


### PR DESCRIPTION
Kill processes listening on a given port.

```
kill-pid-on-port 3000
```