### PR TITLE
all: configure for Apple Silicon M1 chip

### DIFF
--- a/dotfiles/editor/vim/coc-settings.json
+++ b/dotfiles/editor/vim/coc-settings.json
@@ -1,3 +1,3 @@
 {
-  "tsserver.npm": "/Users/croaky/.asdf/shims/npm"
+  "tsserver.npm": "/opt/homebrew/bin/npm"
 }

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -59,7 +59,11 @@ call plug#begin('~/.vim/plugged')
   Plug 'tpope/vim-projectionist'
 
   " Fuzzy-finding binary installed via Homebrew
-  Plug '/usr/local/opt/fzf'
+  if trim(system('uname -m')) == 'arm64'
+    Plug '/opt/homebrew/opt/fzf'
+  else
+    Plug '/usr/local/opt/fzf'
+  endif
 
   " Fuzzy-finding :Ag, :Commits, :Files
   Plug 'junegunn/fzf.vim'

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -93,7 +93,7 @@ PATH="$HOME/.asdf/bin:$PATH"
 PATH="$HOME/.asdf/shims:$PATH"
 
 # Prepend Go binaries
-# PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+PATH="$BREW/go/bin:$HOME/go/bin:$PATH"
 
 # Prepend Deno binaries
 export DENO_INSTALL="$HOME/.deno"

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -1,5 +1,14 @@
 #!/usr/bin/env zsh
 
+# arm64 or x86_64
+arch="$(uname -m)"
+
+if [ "$arch" = "arm64" ]; then
+  BREW="/opt/homebrew"
+else
+  BREW="/usr/local"
+fi
+
 # Aliases
 alias b="bundle"
 alias c="git create-branch"
@@ -40,9 +49,9 @@ SAVEHIST=4096
 unset HOMEBREW_NO_ANALYTICS
 
 # fzf for finding files, ag for searching files
-if [ -d /usr/local/opt/fzf/shell ]; then
-  source "/usr/local/opt/fzf/shell/completion.zsh"
-  source "/usr/local/opt/fzf/shell/key-bindings.zsh"
+if [ -d "$BREW/opt/fzf/shell" ]; then
+  source "$BREW/opt/fzf/shell/completion.zsh"
+  source "$BREW/opt/fzf/shell/key-bindings.zsh"
 fi
 export FZF_DEFAULT_COMMAND='ag --hidden --nocolor -g ""'
 
@@ -77,18 +86,14 @@ export LAPTOP="$HOME/laptop"
 export CDPATH="$CDPATH:$HOME/src/github.com"
 
 # Prepend Homebrew binaries
-PATH="/usr/local/bin:$PATH"
+PATH="$BREW/bin:$PATH"
 
 # Prepend programming language binaries via ASDF shims
 PATH="$HOME/.asdf/bin:$PATH"
 PATH="$HOME/.asdf/shims:$PATH"
 
 # Prepend Go binaries
-PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
-
-# Prepend Deno binaries
-export DENO_INSTALL="$HOME/.deno"
-PATH="$DENO_INSTALL/bin:$PATH"
+# PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
 # Prepend Postgres.app tools
 PATH="/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH"

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -95,6 +95,10 @@ PATH="$HOME/.asdf/shims:$PATH"
 # Prepend Go binaries
 # PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
+# Prepend Deno binaries
+export DENO_INSTALL="$HOME/.deno"
+PATH="$DENO_INSTALL/bin:$PATH"
+
 # Prepend Postgres.app tools
 PATH="/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH"
 

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -85,15 +85,15 @@ export LAPTOP="$HOME/laptop"
 # Change into most common directories
 export CDPATH="$CDPATH:$HOME/src/github.com"
 
-# Prepend Homebrew binaries
-PATH="$BREW/bin:$PATH"
-
 # Prepend programming language binaries via ASDF shims
 PATH="$HOME/.asdf/bin:$PATH"
 PATH="$HOME/.asdf/shims:$PATH"
 
 # Prepend Go binaries
 PATH="$BREW/go/bin:$HOME/go/bin:$PATH"
+
+# Prepend Homebrew binaries
+PATH="$BREW/bin:$PATH"
 
 # Prepend Deno binaries
 export DENO_INSTALL="$HOME/.deno"

--- a/laptop.sh
+++ b/laptop.sh
@@ -138,6 +138,9 @@ esac
   ln -sf "$PWD/sql/psqlrc" "$HOME/.psqlrc"
 )
 
+# Deno
+curl -fsSL https://deno.land/x/install/install.sh | sh
+
 # ASDF
 if [ -d "$HOME/.asdf" ]; then
   (

--- a/laptop.sh
+++ b/laptop.sh
@@ -9,8 +9,8 @@
 # - installs or updates Vim plugins
 
 # This script can be safely run multiple times.
-# It is tested on Big Sur (11.1) and macOS Catalina (10.15)
-# and on arm64 (Apple Silicon) and x86_64 (Intel) chips.
+# Tested with Big Sur (11.1) on arm64 (Apple Silicon) and x86_64 (Intel) chips
+# and with macOS Catalina (10.15) on x86_64 (Intel) chip.
 
 set -eux
 

--- a/laptop.sh
+++ b/laptop.sh
@@ -155,22 +155,11 @@ PATH="$HOME/.asdf/bin:$PATH"
 PATH="$HOME/.asdf/shims:$PATH"
 export PATH
 
-asdf_plugin_update() {
-  if ! asdf plugin-list | grep -Fq "$1"; then
-    asdf plugin-add "$1" "$2"
-  fi
-
-  asdf plugin-update "$1"
-}
-
-# Node
-npm config set scripts-prepend-node-path true
-npm i -g prettier          # auto-formatting
-npm i -g pnpm              # fast package management
-npm i -g npm-check-updates # ncu -u
-
 # Ruby
-asdf_plugin_update "ruby" "https://github.com/asdf-vm/asdf-ruby"
+if ! asdf plugin-list | grep -Fq "ruby"; then
+  asdf plugin-add "ruby" "https://github.com/asdf-vm/asdf-ruby"
+fi
+asdf plugin-update "ruby"
 asdf install ruby 2.7.2
 asdf install ruby 3.0.0
 

--- a/laptop.sh
+++ b/laptop.sh
@@ -8,28 +8,30 @@
 # - installs programming language runtimes
 # - installs or updates Vim plugins
 
-# This script can be run safely multiple times.
-# It is tested on macOS Catalina (10.15).
+# This script can be safely run multiple times.
+# It is tested on Big Sur (11.1) and macOS Catalina (10.15)
+# and on arm64 (Apple Silicon) and x86_64 (Intel) chips.
 
 set -eux
 
-# Homebrew packages
-HOMEBREW_PREFIX="/usr/local"
+# arm64 or x86_64
+arch="$(uname -m)"
 
-if [ -d "$HOMEBREW_PREFIX" ]; then
-  if ! [ -r "$HOMEBREW_PREFIX" ]; then
-    sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
-  fi
+# Homebrew
+if [ "$arch" = "arm64" ]; then
+  BREW="/opt/homebrew"
 else
-  sudo mkdir "$HOMEBREW_PREFIX"
-  sudo chflags norestricted "$HOMEBREW_PREFIX"
-  sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
+  BREW="/usr/local"
 fi
 
-if ! command -v brew >/dev/null; then
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-  export PATH="/usr/local/bin:$PATH"
+if [ ! -d "$BREW" ]; then
+  sudo mkdir -p "$BREW"
+  sudo chflags norestricted "$BREW"
+  sudo chown -R "$LOGNAME:admin" "$BREW"
+  curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C "$BREW"
 fi
+
+export PATH="$BREW/bin:$PATH"
 
 brew analytics off
 brew update-reset
@@ -42,12 +44,14 @@ brew "bat"
 brew "fzf"
 brew "gh"
 brew "git"
+brew "go"
 brew "heroku"
 brew "jq"
 brew "libyaml"
+brew "node"
 brew "openssl"
 brew "pgformatter"
-brew "shellcheck"
+# brew "shellcheck" no M1 support yet
 brew "the_silver_searcher"
 brew "tldr"
 brew "tmux"
@@ -56,8 +60,8 @@ brew "vim"
 brew "watch"
 brew "zsh"
 
-cask "kitty"
-cask "ngrok"
+cask "iterm2"
+# cask "kitty" no M1 support yet
 EOF
 
 brew upgrade
@@ -65,23 +69,20 @@ brew cleanup
 
 # zsh
 update_shell() {
-  (
-    sudo chown -R $(whoami) /usr/local/share/zsh /usr/local/share/zsh/site-functions
-    chmod u+w /usr/local/share/zsh /usr/local/share/zsh/site-functions
-  )
+  sudo chown -R $(whoami) "$BREW/share/zsh" "$BREW/share/zsh/site-functions"
+  chmod u+w "$BREW/share/zsh" "$BREW/share/zsh/site-functions"
+  shellpath="$(command -v zsh)"
 
-  local shell_path;
-  shell_path="$(command -v zsh)"
-
-  if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
-    sudo sh -c "echo $shell_path >> /etc/shells"
+  if ! grep "$shellpath" /etc/shells > /dev/null 2>&1 ; then
+    sudo sh -c "echo $shellpath >> /etc/shells"
   fi
-  chsh -s "$shell_path"
+
+  chsh -s "$shellpath"
 }
 
 case "$SHELL" in
   */zsh)
-    if [ "$(command -v zsh)" != "$HOMEBREW_PREFIX/bin/zsh" ] ; then
+    if [ "$(command -v zsh)" != "$BREW/bin/zsh" ] ; then
       update_shell
     fi
     ;;
@@ -137,17 +138,6 @@ esac
   ln -sf "$PWD/sql/psqlrc" "$HOME/.psqlrc"
 )
 
-# Go
-gover="1.15.4"
-if ! go version | grep -Fq "$gover"; then
-  sudo rm -rf /usr/local/go
-  curl "https://dl.google.com/go/go$gover.darwin-amd64.tar.gz" | \
-    sudo tar xz -C /usr/local
-fi
-
-# Deno
-curl -fsSL https://deno.land/x/install/install.sh | sh
-
 # ASDF
 if [ -d "$HOME/.asdf" ]; then
   (
@@ -171,15 +161,10 @@ asdf_plugin_update() {
 }
 
 # Node
-asdf_plugin_update "nodejs" "https://github.com/asdf-vm/asdf-nodejs"
-export NODEJS_CHECK_SIGNATURES=no
-asdf install nodejs 15.0.1
-asdf global nodejs 15.0.1
 npm config set scripts-prepend-node-path true
 npm i -g prettier          # auto-formatting
 npm i -g pnpm              # fast package management
 npm i -g npm-check-updates # ncu -u
-asdf reshim nodejs
 
 # Ruby
 asdf_plugin_update "ruby" "https://github.com/asdf-vm/asdf-ruby"

--- a/laptop.sh
+++ b/laptop.sh
@@ -46,7 +46,7 @@ brew "gh"
 brew "git"
 brew "go"
 brew "heroku"
-brew "iterm2"
+brew "iterm2" # kitty replacement until M1 support
 brew "jq"
 # brew "kitty" no M1 support yet
 brew "libyaml"

--- a/laptop.sh
+++ b/laptop.sh
@@ -46,11 +46,8 @@ brew "gh"
 brew "git"
 brew "go"
 brew "heroku"
-brew "iterm2" # kitty replacement until M1 support
 brew "jq"
-# brew "kitty" no M1 support yet
 brew "libyaml"
-brew "ngrok"
 brew "node"
 brew "openssl"
 brew "pgformatter"
@@ -62,6 +59,10 @@ brew "tree"
 brew "vim"
 brew "watch"
 brew "zsh"
+
+cask "iterm2" # kitty replacement until M1 support
+# cask "kitty" no M1 support yet
+cask "ngrok"
 EOF
 
 brew upgrade

--- a/laptop.sh
+++ b/laptop.sh
@@ -46,8 +46,11 @@ brew "gh"
 brew "git"
 brew "go"
 brew "heroku"
+brew "iterm2"
 brew "jq"
+# brew "kitty" no M1 support yet
 brew "libyaml"
+brew "ngrok"
 brew "node"
 brew "openssl"
 brew "pgformatter"
@@ -59,9 +62,6 @@ brew "tree"
 brew "vim"
 brew "watch"
 brew "zsh"
-
-cask "iterm2"
-# cask "kitty" no M1 support yet
 EOF
 
 brew upgrade


### PR DESCRIPTION
Set a `$BREW` var in `laptop.sh` and `zshrc` based on architecture.
Use that var as the Homebrew prefix path when needed in scripts.

Previous software I was not able to get working:

* shellcheck
* kitty

I couldn't get Node via ASDF working but Node via Homebrew seems fine.

The Go programming language supports M1 in a beta release:

```
go version go1.16beta1 darwin/arm64
```

Installing Go via Homebrew feels like an elegant way to handle this.
It automatically installs `go1.16beta1` on arm and `go1.15` on x86.