### PR TITLE
dotfiles/vim: increase fzf popup window size

### DIFF
--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -164,6 +164,7 @@ autocmd BufRead setlocal nospell
 
 " Fuzzy-find files
 nmap <C-p> :Files<CR>
+let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.9 } }
 
 " Search file contents
 nmap \ :Ag<SPACE>


### PR DESCRIPTION
The default is width 0.9, height 0.6.
When previewing large files, I'd like more space.

https://sourcegraph.com/github.com/junegunn/fzf/-/blob/README-VIM.md#configuration