### PR TITLE
dotfiles/shell/tmux: support Apple Silicon

### DIFF
--- a/dotfiles/shell/tmux.conf
+++ b/dotfiles/shell/tmux.conf
@@ -1,5 +1,5 @@
 # set Homebrew version of zsh as shell
-set -g default-shell /usr/local/bin/zsh
+set -g default-shell "$BREW/bin/zsh"
 
 # act like GNU screen
 unbind C-b


### PR DESCRIPTION
Homebrew is installed to /opt/homebrew on my M1 laptop.
Use an environment variable to handle both chip architectures.