### PR TITLE
dotfiles/shell/zshrc: remove clone() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ export LAPTOP="$HOME/laptop"
 Clone:
 
 ```
-git clone https://github.com/croaky/laptop.git $LAPTOP
+gh repo clone croaky/laptop $LAPTOP
 cd $LAPTOP
 ```
 

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -17,19 +17,6 @@ alias m="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias mkdir="mkdir -p"
 alias path='echo $PATH | tr -s ":" "\n"'
 
-# clone https://github.com/statusok/genblog
-# clones the repo to $HOME/src/github.com/statusok/genblog
-function clone() {
-  host=$(echo "$1" | cut -d / -f 3)
-  user=$(echo "$1" | cut -d / -f 4)
-  repo=$(echo "$1" | cut -d / -f 5)
-
-  mkdir -p "$HOME/src/$host/$user"
-  cd "$HOME/src/$host/$user" || exit
-  git clone "git@$host:$user/$repo".git
-  cd "$repo" || exit
-}
-
 # Autocomplete branch names for git delete-branch
 function _git_delete_branch() {
   __gitcomp "$(__git_heads)"

--- a/laptop.sh
+++ b/laptop.sh
@@ -149,7 +149,7 @@ if [ -d "$HOME/.asdf" ]; then
     git reset --hard origin/master
   )
 else
-  git clone https://github.com/asdf-vm/asdf.git "$HOME/.asdf"
+  gh repo clone asdf-vm/asdf "$HOME/.asdf"
 fi
 PATH="$HOME/.asdf/bin:$PATH"
 PATH="$HOME/.asdf/shims:$PATH"


### PR DESCRIPTION
Use GitHub CLI's `gh repo clone user/repo` instead.