### PR TITLE
dotfiles/shell/zshrc: keep shorter history

### DIFF
--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -42,8 +42,8 @@ export EDITOR=$VISUAL
 # History
 setopt hist_ignore_all_dups inc_append_history
 HISTFILE=~/.zhistory
-HISTSIZE=4096
-SAVEHIST=4096
+HISTSIZE=500
+SAVEHIST=500
 
 # Disable Homebrew analytics https://docs.brew.sh/Analytics
 unset HOMEBREW_NO_ANALYTICS


### PR DESCRIPTION
Shorten zsh shell history by about 90%.

My thought is this improves security by:

1. lowering the chances of a credential being left in the history file
2. makes the file easier to review manually and remove sensitive lines