### PR TITLE
dotfiles/vim: adjust coc.vim colors

### DIFF
--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -242,6 +242,7 @@ hi gitCommitDiff  ctermfg=250
 
 " Pink
 hi CocErrorSign   ctermfg=161
+hi CocInfoSign    ctermfg=161
 hi CocWarningSign ctermfg=161
 hi DiffDelete     ctermfg=161
 hi Directory      ctermfg=161
@@ -257,11 +258,13 @@ hi diffRemoved    ctermfg=161
 hi rubySymbol     ctermfg=161
 
 " Turquoise
-hi Constant       ctermfg=30
-hi DiffAdd        ctermfg=30 ctermbg=194
-hi Identifier     ctermfg=30
-hi Number         ctermfg=30
-hi Special        ctermfg=30
-hi Type           ctermfg=30
-hi WildMenu       ctermfg=30 ctermbg=60
-hi diffAdded      ctermfg=30
+hi CocHintSign     ctermfg=30
+hi CocMarkdownLink ctermfg=30
+hi Constant        ctermfg=30
+hi DiffAdd         ctermfg=30 ctermbg=194
+hi Identifier      ctermfg=30
+hi Number          ctermfg=30
+hi Special         ctermfg=30
+hi Type            ctermfg=30
+hi WildMenu        ctermfg=30 ctermbg=60
+hi diffAdded       ctermfg=30


### PR DESCRIPTION
The yellow text on white background was hard to read.