### PR TITLE
all: improve environment for Deno, TypeScript

### DIFF
--- a/dotfiles/editor/vim/ftdetect/typescript.vim
+++ b/dotfiles/editor/vim/ftdetect/typescript.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.ts,*.tsx set filetype=typescript

--- a/dotfiles/editor/vim/ftplugin/typescript.vim
+++ b/dotfiles/editor/vim/ftplugin/typescript.vim
@@ -1,6 +1,9 @@
 " Auto-fix
-let b:ale_fixers = ['prettier']
-let g:ale_fix_on_save = 1
+let b:ale_fixers = {'typescript': ['deno']}
+let g:ale_fix_on_save = 1 " run deno fmt when saving a buffer
 
 " Lint
 let b:ale_linters = ['tsserver']
+
+" Run current file
+nmap <buffer> <Leader>r :!clear && deno run %<CR>

--- a/dotfiles/editor/vim/syntax/typescriptreact.vim
+++ b/dotfiles/editor/vim/syntax/typescriptreact.vim
@@ -1,1 +1,0 @@
-runtime! syntax/typescript.vim

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -121,6 +121,7 @@ augroup END
 " https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions
 let g:coc_global_extensions = [
   \ 'coc-css',
+  \ 'coc-deno',
   \ 'coc-git',
   \ 'coc-go',
   \ 'coc-html',
@@ -251,6 +252,7 @@ hi Function       ctermfg=161 ctermbg=231
 hi ModeMsg        ctermfg=161
 hi MoreMsg        ctermfg=161
 hi SpecialKey     ctermfg=161
+hi Search         ctermfg=161 ctermbg=231
 hi String         ctermfg=161
 hi Title          ctermfg=161
 hi WarningMsg     ctermfg=161

--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -61,8 +61,9 @@ if ! env | grep -q '^PS1='; then
 fi
 
 # Completion
-autoload -U compinit
-compinit
+fpath=(~/.zsh $fpath)
+autoload -Uz compinit
+compinit -u
 
 # Set environment variables for monorepos
 export BLOG="$HOME/blog"

--- a/laptop.sh
+++ b/laptop.sh
@@ -145,6 +145,11 @@ fi
 
 # Deno
 curl -fsSL https://deno.land/x/install/install.sh | sh
+mkdir ~/.zsh
+deno completions zsh > ~/.zsh/_deno
+
+# Deno Deploy https://github.com/denoland/deployctl
+deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
 
 # ASDF
 if [ -d "$HOME/.asdf" ]; then


### PR DESCRIPTION
ALE fix with `deno fmt` in TypeScript files, if present.

Remove some TypeScript-specific detection files
that are no longer needed as Vim plugins have improved.

Add `<Leader>r` command to run the current TypeScript file with Deno.
I have similar commands set up for Ruby, Go, and SQL.
https://dancroak.com/run-sql-from-vim
I use `<Leader>r` every day in those other environments.
It is one of my most-used commands.

Improve the highlight color for one of the highlight groups
that is used when jumping to definition with `coc-deno`.

Add zsh auto-completion for the `deno` command.
One cool thing about `deno` is their guarantee that

> Deno will always be distributed as a single executable.

https://deno.land/manual@v1.8.3/introduction#philosophy

Install the `deployctl` command.
This is used to run Deno Deploy apps locally.
https://github.com/denoland/deployctl