### PR TITLE
vim/after/syntax/ruby: highlight SQL heredocs

### DIFF
--- a/vim/after/syntax/ruby.vim
+++ b/vim/after/syntax/ruby.vim
@@ -1,0 +1,6 @@
+" <<~SQL heredocs
+let s:previous_syntax = b:current_syntax
+unlet b:current_syntax
+syntax include @SQL syntax/sql.vim
+syntax region rubyHeredocSQL matchgroup=Statement start=+<<\~\z(SQL\)+ end=+\s\+\z1$+ contains=@SQL,rubyInterpolation
+let b:current_syntax = s:previous_syntax


### PR DESCRIPTION
For example:

```ruby
exec <<~SQL
  SELECT name, score
  FROM companies
SQL
```