### PR TITLE
vim/typescript: remove unused

### DIFF
--- a/vim/ftplugin/typescript.vim
+++ b/vim/ftplugin/typescript.vim
@@ -1,9 +1,9 @@
 " Auto-fix
-let b:ale_fixers = ['deno']
-let g:ale_fix_on_save = 1 " run deno fmt when saving a buffer
+let b:ale_fixers = ['prettier'] " ['deno']
+let g:ale_fix_on_save = 1
 
 " Lint
 let b:ale_linters = ['tsserver']
 
-" Run current file
+" Run current file w/ Deno
 nmap <buffer> <Leader>r :!clear && deno run %<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -146,14 +146,6 @@ function! s:check_back_space() abort
   return !col || getline('.')[col - 1]  =~# '\s'
 endfunction
 
-function! s:show_documentation()
-  if (index(['vim','help'], &filetype) >= 0)
-    execute 'h '.expand('<cword>')
-  else
-    call CocAction('doHover')
-  endif
-endfunction
-
 " Disable spelling by default, enable per-filetype
 autocmd BufRead setlocal nospell
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -131,7 +131,6 @@ let g:coc_global_extensions = [
 
 " Jump to definition
 nnoremap <silent> gd <Plug>(coc-definition)
-nnoremap <silent> gy <Plug>(coc-type-definition)
 nnoremap <silent> gi <Plug>(coc-implementation)
 nnoremap <silent> gr <Plug>(coc-references)
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -130,10 +130,10 @@ let g:coc_global_extensions = [
   \ ]
 
 " Jump to definition
-nmap <silent> gd <Plug>(coc-definition)
-nmap <silent> gy <Plug>(coc-type-definition)
-nmap <silent> gi <Plug>(coc-implementation)
-nmap <silent> gr <Plug>(coc-references)
+nnoremap <silent> gd <Plug>(coc-definition)
+nnoremap <silent> gy <Plug>(coc-type-definition)
+nnoremap <silent> gi <Plug>(coc-implementation)
+nnoremap <silent> gr <Plug>(coc-references)
 
 " Tab complete with COC
 inoremap <silent><expr> <TAB>
@@ -147,9 +147,6 @@ function! s:check_back_space() abort
   return !col || getline('.')[col - 1]  =~# '\s'
 endfunction
 
-" Docs
-nnoremap <silent> K :call <SID>show_documentation()<CR>
-
 function! s:show_documentation()
   if (index(['vim','help'], &filetype) >= 0)
     execute 'h '.expand('<cword>')
@@ -162,11 +159,11 @@ endfunction
 autocmd BufRead setlocal nospell
 
 " Fuzzy-find files
-nmap <C-p> :Files<CR>
+nnoremap <C-p> :Files<CR>
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.9 } }
 
 " Search file contents
-nmap \ :Ag<SPACE>
+nnoremap \ :Ag<SPACE>
 set grepprg=ag\ --nogroup\ --nocolor
 
 " bind K to grep word under cursor


### PR DESCRIPTION
Roll back Deno experiment for auto-fixing.
This actually worked well but doesn't make sense
in a team environment where Deno isn't used.

Use `noremap` consistently.

Remove unused `show_documentation` function.