### PR TITLE
shell: decrease font size

### DIFF
--- a/shell/kitty.conf
+++ b/shell/kitty.conf
@@ -10,7 +10,7 @@ foreground #000000
 
 # font
 font_family SFMono-Regular
-font_size 16.0
+font_size 14.0
 adjust_line_height 120%
 map cmd+equal change_font_size all +2.0
 map cmd+minus change_font_size all -2.0


### PR DESCRIPTION
I'm developing from my laptop more often.
When I do vertical splits to see a test file on the left
and implementation on the right,
I need a bit more space.

Decreasing the font to 14pt has felt good for this setup.