### PR TITLE
bin/clone: add

### DIFF
--- a/bin/clone
+++ b/bin/clone
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# clone https://github.com/gin-gonic/gin
+# clones the repo to $HOME/src/github.com/gin-gonic/gin
+
+set -eo pipefail
+
+host=$(echo "$1" | cut -d / -f 3)
+user=$(echo "$1" | cut -d / -f 4)
+repo=$(echo "$1" | cut -d / -f 5)
+
+mkdir -p "$HOME/src/$host/$user"
+cd "$HOME/src/$host/$user"
+git clone "git@$host:$user/$repo.git" "$repo"
+cd "$HOME/src/$host/$user/$repo"
+$SHELL


### PR DESCRIPTION
```
clone https://github.com/gin-gonic/gin
````

Clones the repo to `$HOME/src/github.com/gin-gonic/gin`
and `cd`'s into the directory, handling the subshell.