### PR TITLE
README: move binary scanning out of laptop.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cd $LAPTOP
 ## Extras
 
 The following items are not part of the script.
+They generally are more "one time setup" items.
+
+### Keyboard
 
 Configure "System Preferences > Keyboard":
 
@@ -21,13 +24,19 @@ Configure "System Preferences > Keyboard":
 * Set "Delay Until Repeat" to "Short".
 * Set "Modifier Keys > Caps Lock Key" to "^ Control".
 
+### macOS apps
+
 Install macOS apps:
 
 * [Magnet.app](https://apps.apple.com/us/app/magnet/id441258766?mt=12)
 * [Postgres.app](https://postgresapp.com/)
 
+### Chrome extension
+
 Go to <chrome://extensions/>, toggle on "Developer mode",
 click "Load unpacked", and select `$LAPTOP/chrome`.
+
+### SSH key
 
 [Create an SSH key](https://dancroak.com/ssh-ed25519):
 
@@ -39,3 +48,16 @@ cat ~/.ssh/id_ed25519.pub | pbcopy
 ```
 
 [Upload SSH key to GitHub](https://github.com/settings/keys).
+
+### Binary malware scans
+
+A macOS feature that scans new binaries for malware
+adds an extra ~2s on to every build of Go programs,
+disturbing its fast iteration cycle. Disable it by running:
+
+```
+sudo spctl developer-mode enable-terminal
+```
+
+Then, select terminal program (e.g. kitty.app)
+at Preferences > Security & Privacy > Privacy > Developer Tools.

--- a/laptop.sh
+++ b/laptop.sh
@@ -130,12 +130,6 @@ if [ "$(command -v zsh)" != "$BREW/bin/zsh" ] ; then
   chsh -s "$shellpath"
 fi
 
-# Whitelist terminal for MacOS malware scanning of binaries.
-# Requires additional (one-time) step of enabling terminal program (e.g. kitty)
-# at Preferences > Security & Privacy > Privacy > Developer Tools
-# https://stackoverflow.com/a/59229195
-sudo spctl developer-mode enable-terminal
-
 # Go
 if ! command -v godoc &> /dev/null; then
   go get golang.org/x/tools/cmd/godoc


### PR DESCRIPTION
The additional `sudo` kind of disturbs the script.
This should also only be necessary each time there's a new kitty.app?