### PR TITLE
bin/git-pr: work around PR formatting

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -2,4 +2,5 @@
 
 set -e
 
-gh pr create --web
+gh pr create --fill
+gh pr view --web


### PR DESCRIPTION
Previously, I'd type `git pr` from my branch
to open GitHub in the browser with a pull request prepared,
but not yet created.

This worked well until a recent change would try to "improve" formatting
of your pull request description by removing certain newlines.

I want to preserve these intentionally-written newlines
in the pull request description,
which also end up being in the commit message when I squash and merge.

Change this helper command to wrap two other `gh` commands,
which will preserve the newlines, create the pull request,
and then open the created pull request.

```
gh pr create --fill
gh pr view --web
```
