### PR TITLE
shell: delete git delete-branch function

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -16,11 +16,6 @@ alias mkdir="mkdir -p"
 alias path='echo $PATH | tr -s ":" "\n"'
 alias vim="nvim"
 
-# Autocomplete branch names for git delete-branch
-function _git_delete_branch() {
-  __gitcomp "$(__git_heads)"
-}
-
 # Editor
 export VISUAL=nvim
 export EDITOR=$VISUAL


### PR DESCRIPTION
I no longer use this between GitHub's auto-delete branch command
and `git post-land`. Occasionally, I'll have branches that never get to
pull requests and I clean them up manually with normal Git commands:

```
git branch -D name
git push origin :name
```
