### PR TITLE
vim: rework linting for frontend

### DIFF
--- a/vim/ftplugin/css.vim
+++ b/vim/ftplugin/css.vim
@@ -1,8 +1,8 @@
 setlocal iskeyword+=-
 
 " Auto-fix?
-" let b:ale_fixers = ['prettier']
-" let g:ale_fix_on_save = 1
+let b:ale_fixers = ['prettier']
+let g:ale_fix_on_save = 1
 
 " Lint?
-" let b:ale_linters = ['prettier']
+let b:ale_linters = ['prettier']

--- a/vim/ftplugin/graphql.vim
+++ b/vim/ftplugin/graphql.vim
@@ -1,6 +1,0 @@
-" Auto-fix
-let b:ale_fixers = ['prettier']
-let g:ale_fix_on_save = 1
-
-" Lint
-let b:ale_linters = ['prettier']

--- a/vim/ftplugin/json.vim
+++ b/vim/ftplugin/json.vim
@@ -1,3 +1,3 @@
 " Auto-fix
-let b:ale_fixers = ['prettier'] " ['jq']
+let b:ale_fixers = ['jq'] " 'prettier'
 let g:ale_fix_on_save = 1

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -94,7 +94,6 @@ call plug#begin('~/.vim/plugged')
 
   " Frontends
   Plug 'evanleck/vim-svelte'
-  Plug 'jparise/vim-graphql'
   Plug 'leafgarland/typescript-vim'
   Plug 'mxw/vim-jsx'
   Plug 'pangloss/vim-javascript'


### PR DESCRIPTION
* Re-enable auto-fixing and linting with Prettier for CSS.
* Remove unused GraphQL config.
* Format JSON with `jq` to match existing style in current project.
