### PR TITLE
shell/kitty: decrease font size

### DIFF
--- a/shell/kitty.conf
+++ b/shell/kitty.conf
@@ -18,15 +18,10 @@ foreground #000000
 
 # font
 font_family SFMono-Regular
-font_size 16.0
+font_size 14.0
 adjust_line_height 120%
 map cmd+equal change_font_size all +2.0
 map cmd+minus change_font_size all -2.0
-
-# allow <c-_><c-_> to run :TComment in Vim
-# https://github.com/tomtom/tcomment_vim
-map ctrl+shift+equal no_op
-map ctrl+shift+minus no_op
 
 # clear
 map cmd+k combine : clear_terminal scrollback active : send_text normal \x0c


### PR DESCRIPTION
The first thing I do when I open kitty is decrease.

Also remove unused commenting commands.
I've gotten used to `gc`.
