### PR TITLE
bin/kill-pid-running: add

### DIFF
--- a/bin/kill-pid-running
+++ b/bin/kill-pid-running
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Kill running process by its name.
+#
+# kill-pid-running sqls
+
+ps aux | awk '/$1/ && !/awk/ {print $2}'


### PR DESCRIPTION
Similar to the other script `kill-pid-on-port`,
this kills a running process with a given name.

I've needed this recently as I've been trying
`sqls`, a language server for SQL that connects
to my app's database in order to provide cool
in-editor stuff. But then, when I want to do a
`pg_restore`, there's a connection open,
which I needed to find and kill.
This does it in one step.
