### PR TITLE
shell,vim: switch to dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ cd $LAPTOP
 ./laptop.sh
 ```
 
-![screenshot](https://user-images.githubusercontent.com/198/116731106-23792180-a99e-11eb-8afc-ecbbcdf58940.png)
-
 ## Extras
 
 The following items are not part of the script.
@@ -20,16 +18,16 @@ They generally are more "one time setup" items.
 
 Configure "System Preferences > Keyboard":
 
-* Set "Key Repeat" to "Fast".
-* Set "Delay Until Repeat" to "Short".
-* Set "Modifier Keys > Caps Lock Key" to "^ Control".
+- Set "Key Repeat" to "Fast".
+- Set "Delay Until Repeat" to "Short".
+- Set "Modifier Keys > Caps Lock Key" to "^ Control".
 
 ### macOS apps
 
 Install macOS apps:
 
-* [Magnet.app](https://apps.apple.com/us/app/magnet/id441258766?mt=12)
-* [Postgres.app](https://postgresapp.com/)
+- [Magnet.app](https://apps.apple.com/us/app/magnet/id441258766?mt=12)
+- [Postgres.app](https://postgresapp.com/)
 
 ### SSH key
 

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -26,8 +26,6 @@
 [diff]
   noprefix = true
   tool = vimdiff
-[diff "rspec"]
-  xfuncname = "^[ \t]*((RSpec|describe|context|it)[ \t].*)$"
 [fetch]
   prune = true
 [github]
@@ -40,7 +38,7 @@
   ff = only
   tool = vimdiff
 [mergetool "vimdiff"]
-  cmd = vimdiff -f $LOCAL $MERGED $REMOTE
+  path = nvim
 [pretty]
   basic = format:%C(red)%h%C(reset) %s%C(reset)
   time = format:%C(red)%h%C(reset) %C(blue)%cs%C(reset) %s%C(reset)

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -38,7 +38,7 @@
   ff = only
   tool = vimdiff
 [mergetool "vimdiff"]
-  path = nvim
+  path = nvim -f $LOCAL $MERGED $REMOTE
 [pretty]
   basic = format:%C(red)%h%C(reset) %s%C(reset)
   time = format:%C(red)%h%C(reset) %C(blue)%cs%C(reset) %s%C(reset)

--- a/laptop.sh
+++ b/laptop.sh
@@ -25,13 +25,13 @@ fi
   ln -sf "$PWD/asdf/tool-versions" "$HOME/.tool-versions"
 
   ln -sf "$PWD/vim/vimrc" "$HOME/.vimrc"
-  mkdir -p "$HOME/.vim/ftdetect"
-  mkdir -p "$HOME/.vim/ftplugin"
-  mkdir -p "$HOME/.vim/syntax"
+  mkdir -p "$HOME/.config/nvim/ftdetect"
+  mkdir -p "$HOME/.config/nvim/ftplugin"
+  mkdir -p "$HOME/.config/nvim/syntax"
   (
     cd vim
     for f in {ftdetect,ftplugin,syntax}/*; do
-      ln -sf "$PWD/$f" "$HOME/.vim/$f"
+      ln -sf "$PWD/$f" "$HOME/.config/nvim/$f"
     done
   )
   mkdir -p "$HOME/.config/nvim"
@@ -54,9 +54,6 @@ fi
 
   mkdir -p "$HOME/.ssh"
   ln -sf "$PWD/shell/ssh" "$HOME/.ssh/config"
-
-  mkdir -p "$HOME/.config/bat"
-  ln -sf "$PWD/shell/bat" "$HOME/.config/bat/config"
 
   ln -sf "$PWD/shell/curlrc" "$HOME/.curlrc"
   ln -sf "$PWD/shell/hushlogin" "$HOME/.hushlogin"
@@ -87,7 +84,6 @@ tap "heroku/brew"
 
 brew "asdf"
 brew "awscli"
-brew "bat"
 brew "crystal"
 brew "fzf"
 brew "gh"

--- a/shell/kitty.conf
+++ b/shell/kitty.conf
@@ -12,9 +12,9 @@ export KITTY_LISTEN_ON=unix:/tmp/mykitty-$PPID
 hide_window_decorations no
 
 # color
-background #ffffff
+background #191e2d
 cursor #cccccc
-foreground #000000
+foreground #ffffff
 
 # font
 font_family SFMono-Regular

--- a/vim/ftdetect/git.vim
+++ b/vim/ftdetect/git.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.git/COMMIT_EDITMSG set syntax=gitcommit

--- a/vim/ftdetect/git.vim
+++ b/vim/ftdetect/git.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.git/COMMIT_EDITMSG set syntax=gitcommit

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -162,30 +162,36 @@ endif
 " https://neovim.io/doc/user/treesitter.html#treesitter-highlight
 
 " Dim, sync w/ shell/kitty.conf background
-hi SignColumn     guibg=#191e2d
+hi SignColumn                           guibg=#191e2d
 
 " Light gray
-hi Comment        guifg=#cccccc
-hi Cursor         guifg=#cccccc
-hi Error          guifg=#cccccc
-hi Ignore         guifg=#cccccc
-hi LineNr         guifg=#cccccc
-hi NonText        guifg=#cccccc
-hi PmenuSel       guifg=#cccccc
-hi PreProc        guifg=#cccccc
-hi Special        guifg=#cccccc
-hi SpecialKey     guifg=#cccccc
-hi StatusLine     guifg=#cccccc
-hi StatusLineNC   guifg=#cccccc
-hi TabLine        guifg=#cccccc
-hi TabLineFill    guifg=#cccccc
-hi TabLineSel     guifg=#cccccc
-hi Todo           guifg=#cccccc
-hi VertSplit      guifg=#cccccc
-hi Visual         guifg=#cccccc
+hi Comment               guifg=#cccccc
+hi Cursor                guifg=#cccccc
+hi Error                 guifg=#cccccc
+hi Ignore                guifg=#cccccc
+hi LineNr                guifg=#cccccc
+hi NonText               guifg=#cccccc
+hi SpecialKey            guifg=#cccccc
+hi StatusLine            guifg=#cccccc
+hi StatusLineNC          guifg=#cccccc
+hi TabLine               guifg=#cccccc
+hi TabLineFill           guifg=#cccccc
+hi TabLineSel            guifg=#cccccc
+hi VertSplit             guifg=#cccccc
+hi Visual                guifg=#cccccc
 
 " Pink
-hi diffRemoved    guifg=#d7005f
+hi diffRemoved           guifg=#d7005f
+hi ColorColumn                          guibg=#d7005f
+hi DiagnosticError       guifg=#d7005f
+hi DiffText                             guibg=#d7005f
+hi Error                                guibg=#d7005f
+hi ErrorMsg                             guibg=#d7005f
+hi NvimInternalError     guifg=#ffffff  guibg=#d7005f
+hi Pmenu                                guibg=#d7005f
+hi RedrawDebugRecompose                 guibg=#d7005f
+hi Title                 guifg=#d7005f
+hi WarningMsg            guifg=#d7005f
 
 " Turquoise
-hi diffAdded      guifg=#008787
+hi diffAdded             guifg=#008787

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -162,36 +162,50 @@ endif
 " https://neovim.io/doc/user/treesitter.html#treesitter-highlight
 
 " Dim, sync w/ shell/kitty.conf background
-hi SignColumn                           guibg=#191e2d
+hi SignColumn                      guibg=#191e2d
+
+" White
+hi Identifier         guifg=#ffffff
 
 " Light gray
-hi Comment               guifg=#cccccc
-hi Cursor                guifg=#cccccc
-hi Error                 guifg=#cccccc
-hi Ignore                guifg=#cccccc
-hi LineNr                guifg=#cccccc
-hi NonText               guifg=#cccccc
-hi SpecialKey            guifg=#cccccc
-hi StatusLine            guifg=#cccccc
-hi StatusLineNC          guifg=#cccccc
-hi TabLine               guifg=#cccccc
-hi TabLineFill           guifg=#cccccc
-hi TabLineSel            guifg=#cccccc
-hi VertSplit             guifg=#cccccc
-hi Visual                guifg=#cccccc
+hi Comment            guifg=#999999
+hi Cursor             guifg=#999999
+hi Ignore             guifg=#999999
+hi Keyword            guifg=#999999
+hi LineNr             guifg=#999999
+hi NonText            guifg=#999999
+hi Operator           guifg=#999999
+hi Special            guifg=#999999
+hi StatusLine         guifg=#999999
+hi TabLine            guifg=#999999
+hi VertSplit          guifg=#999999
+hi Visual             guifg=#999999
+
+" Yellow
+hi DiagnosticWarn     guifg=#ffd080
+hi Type               guifg=#ffd080
+hi Search                            guibg=#ffd080
+hi String             guifg=#ffd080
+
+" Purple
+hi Function           guifg=#9664c8
+hi PreProc            guifg=#9664c8
 
 " Pink
-hi diffRemoved           guifg=#d7005f
-hi ColorColumn                          guibg=#d7005f
-hi DiagnosticError       guifg=#d7005f
-hi DiffText                             guibg=#d7005f
-hi Error                                guibg=#d7005f
-hi ErrorMsg                             guibg=#d7005f
-hi NvimInternalError     guifg=#ffffff  guibg=#d7005f
-hi Pmenu                                guibg=#d7005f
-hi RedrawDebugRecompose                 guibg=#d7005f
-hi Title                 guifg=#d7005f
-hi WarningMsg            guifg=#d7005f
+hi diffRemoved        guifg=#d7005f
+hi Boolean            guifg=#d7005f
+hi ColorColumn                       guibg=#d7005f
+hi Constant           guifg=#d7005f
+hi DiagnosticError    guifg=#d7005f
+hi DiffText                          guibg=#d7005f
+hi Error                             guibg=#d7005f
+hi ErrorMsg                          guibg=#d7005f
+hi Number             guifg=#d7005f
+hi Statement          guifg=#d7005f
+hi Title              guifg=#d7005f
+hi WarningMsg         guifg=#d7005f
 
-" Turquoise
-hi diffAdded             guifg=#008787
+" Green
+hi diffAdded          guifg=#64c88e
+hi DiagnosticInfo     guifg=#64c88e
+hi Directory          guifg=#64c88e

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -185,7 +185,7 @@ hi VertSplit      guifg=#cccccc
 hi Visual         guifg=#cccccc
 
 " Pink
-" hi diffRemoved    guifg=#d7005f
+hi diffRemoved    guifg=#d7005f
 
 " Turquoise
-" hi diffAdded      guifg=#008787
+hi diffAdded      guifg=#008787

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -151,15 +151,19 @@ nnoremap <C-l> <C-w>l
 
 " Colors
 hi clear
+
 if exists("syntax_on")
   syntax reset
 endif
 
-" Show all syntax groups
-" :so $VIMRUNTIME/syntax/hitest.vim
-
 " Delegate most highlighting decisions to Treesitter
 " https://neovim.io/doc/user/treesitter.html#treesitter-highlight
+
+" See highlight group under cursor
+" :TSHighlightCapturesUnderCursor
+
+" Show all syntax groups
+" :so $VIMRUNTIME/syntax/hitest.vim
 
 " Dim, sync w/ shell/kitty.conf background
 hi SignColumn                         guibg=#191e2d

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -162,53 +162,56 @@ endif
 " https://neovim.io/doc/user/treesitter.html#treesitter-highlight
 
 " Dim, sync w/ shell/kitty.conf background
-hi SignColumn                      guibg=#191e2d
+hi SignColumn                         guibg=#191e2d
 
 " White
-hi Identifier         guifg=#ffffff
+hi Identifier            guifg=#ffffff
+hi Keyword               guifg=#ffffff
 
 " Light gray
-hi Comment            guifg=#999999
-hi Cursor             guifg=#999999
-hi Ignore             guifg=#999999
-hi Keyword            guifg=#999999
-hi LineNr             guifg=#999999
-hi NonText            guifg=#999999
-hi Operator           guifg=#999999
-hi Special            guifg=#999999
-hi StatusLine         guifg=#999999
-hi TabLine            guifg=#999999
-hi VertSplit          guifg=#999999
+hi Comment               guifg=#999999
+hi Cursor                guifg=#999999
+hi Ignore                guifg=#999999
+hi LineNr                guifg=#999999
+hi NonText               guifg=#999999
+hi Operator              guifg=#999999
+hi PmenuSel              guifg=#ffffff  guibg=#999999
+hi PmenuThumb            guifg=#ffffff  guibg=#999999
+hi Special               guifg=#999999
+hi StatusLine            guifg=#999999
+hi TabLine               guifg=#ffffff  guibg=#999999
+hi VertSplit             guifg=#999999
 
 " Yellow
-hi DiagnosticWarn     guifg=#ffd080
-hi Type               guifg=#ffd080
-hi Search                            guibg=#ffd080
-hi String             guifg=#ffd080
+hi DiagnosticWarn        guifg=#ffd080
+hi Type                  guifg=#ffd080
+hi RedrawDebugClear      guifg=#ffd080  guibg=#191e2d
+hi Search                               guibg=#ffd080
+hi String                guifg=#ffd080
+hi WildMenu                             guibg=#d7005f
 
 " Purple
-hi Function           guifg=#9664c8
-hi PreProc            guifg=#9664c8
+hi Directory             guifg=#9664c8
+hi Function              guifg=#9664c8
+hi PreProc               guifg=#9664c8
 
 " Pink
-hi diffRemoved        guifg=#d7005f
-hi Boolean            guifg=#d7005f
-hi ColorColumn                       guibg=#d7005f
-hi Constant           guifg=#d7005f
-hi DiagnosticError    guifg=#d7005f
-hi DiffText                          guibg=#d7005f
-hi Error                             guibg=#d7005f
-hi ErrorMsg                          guibg=#d7005f
-hi Pmenu                             guibg=#d7005f
-hi PreProc            guifg=#d7005f
-hi Number             guifg=#d7005f
-hi NvimInternalError  guifg=#ffffff  guibg=#d7005f
-hi Statement          guifg=#d7005f
-hi Title              guifg=#d7005f
-hi WarningMsg         guifg=#d7005f
-hi WildMenu           guifg=#d7005f
+hi diffRemoved           guifg=#d7005f
+hi Boolean               guifg=#d7005f
+hi ColorColumn                          guibg=#d7005f
+hi Constant              guifg=#d7005f
+hi DiagnosticError       guifg=#d7005f
+hi DiffText                             guibg=#d7005f
+hi Error                                guibg=#d7005f
+hi ErrorMsg                             guibg=#d7005f
+hi Pmenu                                guibg=#d7005f
+hi PreProc               guifg=#d7005f
+hi Number                guifg=#d7005f
+hi NvimInternalError     guifg=#ffffff  guibg=#d7005f
+hi RedrawDebugRecompose             guibg=#d7005f
+hi Statement             guifg=#d7005f
+hi Title                 guifg=#d7005f
+hi WarningMsg            guifg=#d7005f
 
 " Green
-hi diffAdded          guifg=#64c88e
-hi DiagnosticInfo     guifg=#64c88e
-hi Directory          guifg=#64c88e
+hi diffAdded             guifg=#64c88e

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -179,7 +179,6 @@ hi Special            guifg=#999999
 hi StatusLine         guifg=#999999
 hi TabLine            guifg=#999999
 hi VertSplit          guifg=#999999
-hi Visual             guifg=#999999
 
 " Yellow
 hi DiagnosticWarn     guifg=#ffd080
@@ -200,10 +199,14 @@ hi DiagnosticError    guifg=#d7005f
 hi DiffText                          guibg=#d7005f
 hi Error                             guibg=#d7005f
 hi ErrorMsg                          guibg=#d7005f
+hi Pmenu                             guibg=#d7005f
+hi PreProc            guifg=#d7005f
 hi Number             guifg=#d7005f
+hi NvimInternalError  guifg=#ffffff  guibg=#d7005f
 hi Statement          guifg=#d7005f
 hi Title              guifg=#d7005f
 hi WarningMsg         guifg=#d7005f
+hi WildMenu           guifg=#d7005f
 
 " Green
 hi diffAdded          guifg=#64c88e

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -32,6 +32,7 @@ set signcolumn=yes
 set splitbelow
 set splitright
 set tabstop=2
+set termguicolors
 set textwidth=80
 set updatetime=300
 
@@ -157,72 +158,30 @@ endif
 " Show all syntax groups
 " :so $VIMRUNTIME/syntax/hitest.vim
 
+" Delegate most highlighting decisions to Treesitter
 " https://neovim.io/doc/user/treesitter.html#treesitter-highlight
 
-" Black
-hi @variable      ctermfg=16
-hi IncSearch      ctermfg=16  ctermbg=189
-hi Label          ctermfg=16
-hi MatchParen     ctermfg=16  ctermbg=189
-hi Normal         ctermfg=16  ctermbg=231
-hi Pmenu          ctermfg=16  ctermbg=231
-hi PmenuSbar      ctermfg=16  ctermbg=231
-hi PmenuThumb     ctermfg=16  ctermbg=231
-hi Search         ctermfg=16  ctermbg=189
-hi Statement      ctermfg=16
-hi StorageClass   ctermfg=16
-hi Structure      ctermfg=16
-hi TypeDef        ctermfg=16
-hi Underlined     ctermfg=16 cterm=NONE
-hi rubyDefine     ctermfg=16
-hi rubyMacro      ctermfg=16
-hi rubyValidation ctermfg=16
+" Dim, sync w/ shell/kitty.conf background
+hi SignColumn     guibg=#191e2d
 
 " Light gray
-hi Comment        ctermfg=250
-hi Cursor         ctermfg=250 ctermbg=238
-hi CursorLineNr   ctermfg=250 ctermbg=253
-hi Error          ctermfg=250 ctermbg=231
-hi Folded         ctermfg=250 ctermbg=255
-hi Ignore         ctermfg=250
-hi LineNr         ctermfg=250 ctermbg=255
-hi NonText        ctermfg=250 ctermbg=255
-hi PmenuSel       ctermfg=250 ctermbg=238
-hi PreProc        ctermfg=250
-hi Special        ctermfg=250 ctermbg=231
-hi SpecialKey     ctermfg=250 ctermbg=231
-hi StatusLine     ctermfg=250 ctermbg=255
-hi StatusLineNC   ctermfg=250 ctermbg=255
-hi TabLine        ctermfg=250 ctermbg=253
-hi TabLineFill    ctermfg=250 ctermbg=253
-hi TabLineSel     ctermfg=250
-hi Todo           ctermfg=250 ctermbg=231
-hi VertSplit      ctermfg=250 ctermbg=250
-hi Visual         ctermfg=250 ctermbg=61
-hi VisualNOS      ctermfg=250 ctermbg=24
-hi gitCommitDiff  ctermfg=250
-
-" Pink
-hi DiffDelete     ctermfg=161
-hi Directory      ctermfg=161
-hi ErrorMsg       ctermfg=161 ctermbg=231
-hi Function       ctermfg=161 ctermbg=231
-hi ModeMsg        ctermfg=161
-hi MoreMsg        ctermfg=161
-hi SpecialKey     ctermfg=161
-hi Search         ctermfg=161 ctermbg=231
-hi String         ctermfg=161
-hi Title          ctermfg=161
-hi WarningMsg     ctermfg=161
-hi diffRemoved    ctermfg=161
-hi rubySymbol     ctermfg=161
-
-" Turquoise
-hi Constant       ctermfg=30
-hi DiffAdd        ctermfg=30 ctermbg=194
-hi Identifier     ctermfg=30
-hi Number         ctermfg=30
-hi Special        ctermfg=30
-hi Type           ctermfg=30
-hi WildMenu       ctermfg=30 ctermbg=60
-hi diffAdded      ctermfg=30
+hi Comment        guifg=#cccccc
+hi Cursor         guifg=#cccccc
+hi Error          guifg=#cccccc
+hi Ignore         guifg=#cccccc
+hi LineNr         guifg=#cccccc
+hi NonText        guifg=#cccccc
+hi PmenuSel       guifg=#cccccc
+hi PreProc        guifg=#cccccc
+hi Special        guifg=#cccccc
+hi SpecialKey     guifg=#cccccc
+hi StatusLine     guifg=#cccccc
+hi StatusLineNC   guifg=#cccccc
+hi TabLine        guifg=#cccccc
+hi TabLineFill    guifg=#cccccc
+hi TabLineSel     guifg=#cccccc
+hi Todo           guifg=#cccccc
+hi VertSplit      guifg=#cccccc
+hi Visual         guifg=#cccccc
+hi VisualNOS      guifg=#cccccc
+hi gitCommitDiff  guifg=#cccccc

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -183,5 +183,9 @@ hi TabLineSel     guifg=#cccccc
 hi Todo           guifg=#cccccc
 hi VertSplit      guifg=#cccccc
 hi Visual         guifg=#cccccc
-hi VisualNOS      guifg=#cccccc
-hi gitCommitDiff  guifg=#cccccc
+
+" Pink
+" hi diffRemoved    guifg=#d7005f
+
+" Turquoise
+" hi diffAdded      guifg=#008787

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -196,7 +196,7 @@ hi Function              guifg=#9664c8
 hi PreProc               guifg=#9664c8
 
 " Pink
-hi diffRemoved           guifg=#d7005f
+hi @text.diff.delete     guifg=#d7005f
 hi Boolean               guifg=#d7005f
 hi ColorColumn                          guibg=#d7005f
 hi Constant              guifg=#d7005f
@@ -214,4 +214,4 @@ hi Title                 guifg=#d7005f
 hi WarningMsg            guifg=#d7005f
 
 " Green
-hi diffAdded             guifg=#64c88e
+hi @text.diff.add        guifg=#64c88e


### PR DESCRIPTION
This is mainly accomplished by:

1. Deleting most custom highlights,
   delegating most highlighting decisions to Treesitter.
2. Changing `shell/kitty.conf`'s `background`.
3. `set termguicolors`, which allows colors to be configured in hex.
   This makes it easier for me to match my shell/Vim themes
   with my dancroak.com blog themes.