### PR TITLE
vim/ruby: replace solargraph with standardrb for LSP

### DIFF
--- a/vim/ftplugin/ruby.vim
+++ b/vim/ftplugin/ruby.vim
@@ -1,5 +1,3 @@
-" TODO: try sorbet https://sorbet.org/
-
 " Auto-fix
 let g:ale_fix_on_save = 1
 

--- a/vim/nvim.vim
+++ b/vim/nvim.vim
@@ -71,12 +71,6 @@ lua <<EOF
     capabilities = capabilities,
   }
 
-  -- Ruby
-  lspconfig['solargraph'].setup {
-    on_attach = on_attach,
-    capabilities = capabilities,
-  }
-
   -- TypeScript
   lspconfig['tsserver'].setup {
     on_attach = on_attach,
@@ -100,6 +94,18 @@ lua <<EOF
     on_attach = on_attach,
     capabilities = capabilities,
   }
+
+  -- Ruby
+  vim.api.nvim_create_autocmd("FileType", {
+    pattern = "ruby",
+    group = vim.api.nvim_create_augroup("RubyLSP", { clear = true }),
+    callback = function()
+      vim.lsp.start {
+        name = "standard",
+        cmd = { ".git/safe/../../bin/standardrb", "--lsp" },
+      }
+    end,
+  })
 
   -- Auto pairs
   require'nvim-autopairs'.setup {}


### PR DESCRIPTION
Now in `standard` 1.19.0 via
https://github.com/testdouble/standard/pull/475
