### PR TITLE
vim/ruby: replace Standard with Sorbet and Rubocop

### DIFF
--- a/vim/ftplugin/ruby.vim
+++ b/vim/ftplugin/ruby.vim
@@ -1,9 +1,13 @@
+" Disable ALE for Sorbet type definition files
+let g:ale_pattern_options = { '.*\.rbi$': {'ale_enabled': 0} }
+
 " Auto-fix
 let g:ale_fix_on_save = 1
 
-" Default to standardrb
-let b:ale_fixers = ['standardrb']
-let b:ale_linters = ['standardrb']
+" Default to bundled rubocop
+let g:ale_ruby_rubocop_executable = 'bundle'
+let b:ale_fixers = ['rubocop']
+let b:ale_linters = ['rubocop']
 
 " https://github.com/testdouble/standard/wiki/IDE:-vim
 let g:ruby_indent_assignment_style = 'variable'

--- a/vim/nvim.vim
+++ b/vim/nvim.vim
@@ -96,16 +96,11 @@ lua <<EOF
   }
 
   -- Ruby
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = "ruby",
-    group = vim.api.nvim_create_augroup("RubyLSP", { clear = true }),
-    callback = function()
-      vim.lsp.start {
-        name = "standard",
-        cmd = { "standardrb", "--lsp" },
-      }
-    end,
-  })
+  lspconfig['sorbet'].setup{
+    on_attach = on_attach,
+    capabilities = capabilities,
+    cmd = { "srb", "tc", "--lsp", "--disable-watchman" }
+  }
 
   -- Auto pairs
   require'nvim-autopairs'.setup {}


### PR DESCRIPTION
I did some testing with different Ruby LSP options
and Sorbet was the only one I could get good
"jump to definition" working.

With that in mind, I want to disable linting
when jumping into `.rbi` files.
And, I'd like to auto-fix frozen string literal comments.

I'm keeping my eye on https://github.com/shopify/ruby-lsp
for the future to see what they're able to add for
"jump to definition". Interestingly, they use Sorbet and Rubocop on that
project itself.

In general, I'd like to lean into trying the Stripe + Shopify Ruby
stacks in day-to-day Ruby programming to see how things feel.

While integrating Sorbet into a small project to test these changes,
it immediately found a few problems.
