### PR TITLE
vim/ruby: use Solargraph

### DIFF
--- a/vim/nvim.vim
+++ b/vim/nvim.vim
@@ -96,15 +96,17 @@ lua <<EOF
   }
 
   -- Ruby
-  lspconfig['ruby_ls'].setup{
+  lspconfig['solargraph'].setup{
     on_attach = on_attach,
     capabilities = capabilities,
-    cmd = { "ruby-lsp" },
+    cmd = { "solargraph", "stdio" },
     filetypes = { "ruby" },
-    init_options = {
-      enabledFeatures = { "codeActions", "diagnostics", "documentHighlights", "documentSymbols", "inlayHint" }
-    },
-    root_dir = util.root_pattern("Gemfile", ".git")
+    root_dir = util.root_pattern("Gemfile", ".git"),
+    settings = {
+      solargraph = {
+        diagnostics = false
+      }
+    }
   }
 
   -- Crystal


### PR DESCRIPTION
I've tried many Ruby LSPs now such as Sorbet and Ruby LSP.
In Vim, my biggest need from an LSP is go-to-definition.
Solargraph does the best job of this, for the least effort.
I don't need to install RBI files like in Sorbet.
I don't even need to install Solargraph in my projects'
`Gemfile`: I just install it on my machine, no need to
bother any other teammate.