### PR TITLE
vim: use :redraw! instead of clear

### DIFF
--- a/vim/ftplugin/crystal.vim
+++ b/vim/ftplugin/crystal.vim
@@ -4,5 +4,5 @@ let b:ale_fixers = ['crystal']
 let b:ale_linters = ['crystal']
 
 " Run current file
-nmap <buffer> <Leader>r :!clear && crystal %<CR>
-nmap <buffer> <Leader>t :!clear && KEMAL_ENV=test crystal spec %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!crystal %<CR>
+nmap <buffer> <Leader>t :redraw!<CR>:!KEMAL_ENV=test crystal spec %<CR>

--- a/vim/ftplugin/go.vim
+++ b/vim/ftplugin/go.vim
@@ -18,7 +18,7 @@ setlocal nolist
 compiler go
 
 nmap :A<CR> :GoAlternate<CR>
-nmap <buffer> <Leader>r :!clear && go run %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!go run %<CR>
 
 " Syntax highlight additional tokens
 let g:go_highlight_fields = 1

--- a/vim/ftplugin/lua.vim
+++ b/vim/ftplugin/lua.vim
@@ -3,3 +3,6 @@ let g:ale_fix_on_save = 1
 
 let b:ale_fixers = ['lua-language-server']
 let b:ale_linters = ['lua-language-server']
+
+" Run current file
+nmap <buffer> <Leader>r :redraw!<CR>:!lua %<CR>

--- a/vim/ftplugin/python.vim
+++ b/vim/ftplugin/python.vim
@@ -5,4 +5,4 @@ let b:ale_fixers = ['ruff']
 let b:ale_linters = ['ruff']
 
 " Run current file
-nmap <buffer> <Leader>r :!clear && python3 %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!python3 %<CR>

--- a/vim/ftplugin/ruby.vim
+++ b/vim/ftplugin/ruby.vim
@@ -20,4 +20,4 @@ let b:ale_linters = ['rubocop']
 let g:ruby_indent_assignment_style = 'variable'
 
 " Run current file
-nmap <buffer> <Leader>r :!clear && bundle exec ruby %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!bundle exec ruby %<CR>

--- a/vim/ftplugin/sql.vim
+++ b/vim/ftplugin/sql.vim
@@ -4,7 +4,7 @@ let g:ale_fix_on_save = 1
 let b:ale_sql_pgformatter_options = '--function-case 1 --keyword-case 2 --spaces 2 --no-extra-line'
 
 " Run current file
-nmap <buffer> <Leader>r :!clear && psql -d $(cat .db) -f %<CR>
+nmap <buffer> <Leader>r :redraw!<CR>:!psql -d $(cat .db) -f %<CR>
 
 " Prepare SQL command with var(s)
-nmap <buffer> <Leader>v :!clear && psql -d $(cat .db) -f % -v<SPACE>
+nmap <buffer> <Leader>v :redraw!<CR>:!psql -d $(cat .db) -f % -v<SPACE>

--- a/vim/ftplugin/typescript.vim
+++ b/vim/ftplugin/typescript.vim
@@ -6,4 +6,4 @@ let g:ale_fix_on_save = 1
 let b:ale_linters = ['tsserver']
 
 " Run current file w/ Deno
-" nmap <buffer> <Leader>r :!clear && deno run %<CR>
+" nmap <buffer> <Leader>r :redraw!<CR>:!deno run %<CR>


### PR DESCRIPTION
Previously, I would see output like this:

```
:!clear && echo "" && lua hello.lua
^[[H^[[2J
Name:   Lua
Version:        5.3
Is Lua awesome? true
```

The sequence `^[[H^[[2J` is an ANSI escape code for clearing the screen.
In many terminals:

- `^[[H` moves the cursor to the home position (i.e., the top-left of
  the screen).
- `^[[2J` clears the screen from the cursor to the end of the screen.

When I ran the `clear` command, it sends these escape sequences to the
terminal to clear the screen. However, when I run the command from
within Vim using `:!`, Vim captures and displays the output of the
command, including the escape sequences, which don't get interpreted but
rather get shown as is.

To avoid seeing the escape sequences, replace the `clear` command with
another approach. One way to achieve this without the escape sequences
being printed is by using Vim's built-in command to clear the screen:
`:redraw!`.

```vim
nmap <buffer> <Leader>r :redraw!<CR>:!lua %<CR>
```

With this, `:redraw!` will clear Vim's command-line screen. After that,
the Lua script will run, giving me a clean output without the escape
sequences and without the need for `echo "" &&`.
