### PR TITLE
vim: fix Git commit syntax highlighting

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -46,10 +46,9 @@ set -eux
   ln -sf "$PWD/vim/vimrc" "$HOME/.vimrc"
   mkdir -p "$HOME/.config/nvim/ftdetect"
   mkdir -p "$HOME/.config/nvim/ftplugin"
-  mkdir -p "$HOME/.config/nvim/syntax"
   (
     cd vim
-    for f in {ftdetect,ftplugin,syntax}/*; do
+    for f in {ftdetect,ftplugin}/*; do
       ln -sf "$PWD/$f" "$HOME/.config/nvim/$f"
     done
   )

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -198,6 +198,7 @@ hi Function              guifg=#9664c8
 hi PreProc               guifg=#9664c8
 
 " Pink
+hi @diff.minus           guifg=#d7005f
 hi @symbol               guifg=#d7005f
 hi @text.diff.delete     guifg=#d7005f
 hi Boolean               guifg=#d7005f
@@ -217,4 +218,5 @@ hi Title                 guifg=#d7005f
 hi WarningMsg            guifg=#d7005f
 
 " Green
+hi @diff.plus            guifg=#64c88e
 hi @text.diff.add        guifg=#64c88e


### PR DESCRIPTION
Treesitter now has a different syntax match name.
