### PR TITLE
git: move hard-coded user to ~/.gitconfig.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ cat ~/.ssh/id_ed25519.pub | pbcopy
 
 [Upload the public key to GitHub](https://github.com/settings/keys).
 
+## Git user
+
+Set your Git user name and email:
+
+```
+git config --global user.name "Your Name"
+git config --global user.email you@example.com
+```
+
 ## Install
 
 Clone onto laptop:

--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ cat ~/.ssh/id_ed25519.pub | pbcopy
 
 [Upload the public key to GitHub](https://github.com/settings/keys).
 
-## Git user
+## Git
 
-Set your Git user name and email:
+Set your Git and GitHub user in `~/.gitconfig.local`
+to keep it out of version control:
 
 ```
-git config --global user.name "Your Name"
-git config --global user.email you@example.com
+[github]
+  user = yourgithubusername
+[user]
+  name = Your Name
+  email = you@example.com
 ```
 
 ## Install

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -48,6 +48,3 @@
   autosquash = true
 [rerere]
   enabled = true
-[user]
-  name = Dan Croak
-  email = dan@statusok.com

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -26,8 +26,8 @@
   tool = vimdiff
 [fetch]
   prune = true
-[github]
-  user = croaky
+[include]
+  path = ~/.gitconfig.local
 [init]
   defaultBranch = main
 [merge]


### PR DESCRIPTION
This repo is more easily forked and used by others without
hard-coding my name name and email.