### PR TITLE
shell: adjust fzf config

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -24,6 +24,7 @@ unset HOMEBREW_NO_ANALYTICS
 
 # fzf to find files, ag to search files
 if [ -e "$BREW/opt/fzf/shell" ]; then
+  source "$BREW/opt/fzf/shell/completion.zsh"
   source "$BREW/opt/fzf/shell/key-bindings.zsh"
 fi
 export FZF_DEFAULT_COMMAND='ag --hidden --nocolor -g ""'

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -63,7 +63,7 @@ require("packer").startup(function(use)
 	use("RRethy/nvim-treesitter-endwise")
 
 	-- Fuzzy-finding :Ag, :Commits, :Files
-	use({ "junegunn/fzf", run = ":call fzf#install()" })
+	use({ "junegunn/fzf", dir = "/opt/homebrew/opt/fzf" })
 	use("junegunn/fzf.vim")
 
 	-- :A, .projections.json


### PR DESCRIPTION
Don't install FZF in Vim since we install via Homebrew.
Explicitly tell Packer where to find the FXF install.

Enable FZF's shell completion features:

1. Add fuzzy autocompletion capabilities to various commands. For
   example, when typing a command like `cd`, `ssh`, or `git checkout`, I
   can press `Tab` to trigger FZF’s interactive fuzzy finder to
   autocomplete file paths, branches, or commands.
2. Bind certain key combinations (like `Ctrl-T`, `Ctrl-R`, `Alt-C`) to
   trigger FZF for different actions:
   - `Ctrl-T`: Fuzzy find files and directories to insert into the
     command line.
   - `Ctrl-R`: Fuzzy search through command history.
   - `Alt-C`: Fuzzy change to a directory.
3. Ensure that the FZF completion system is integrated with the shell,
   so it can intercept commands and provide enhanced fuzzy searching
   where applicable.
