### PR TITLE
vim: show active user name in status line

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -54,6 +54,11 @@ compinit -u
 # Bat
 export BAT_THEME="TwoDark"
 
+# Tmux
+if [ -n "$TMUX" ]; then
+  export TMUX_USER="$(whoami)"
+fi
+
 # Go
 PATH="$BREW/go/bin:$HOME/go/bin:$PATH"
 

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -163,6 +163,22 @@ local function format_on_save(cmd_template)
 	})
 end
 
+function _G.tmux_user_or_unix_user_from_env_vars()
+	if vim.env.TMUX ~= nil then
+		local tmux_user = vim.fn.getenv("TMUX_USER")
+		if tmux_user and tmux_user:match("^%w+$") then
+			return "[" .. tmux_user .. "] "
+		end
+	end
+
+	local unix_user = os.getenv("USER") or os.getenv("USERNAME")
+	if unix_user and unix_user:match("^%w+$") then
+		return "[" .. unix_user .. "] "
+	end
+
+	return ""
+end
+
 -- Netrw
 vim.g.netrw_banner = 0
 vim.g.netrw_list_hide = ".DS_Store"
@@ -356,6 +372,10 @@ cmp.setup({
 	}),
 })
 
+-- Status line
+vim.opt.statusline = "%{v:lua.tmux_user_or_unix_user_from_env_vars()}%f %h%m%r%=%-14.(%l,%c%V%) %P"
+
+-- Treesitter
 require("nvim-treesitter.configs").setup({
 	ensure_installed = {
 		"bash",


### PR DESCRIPTION
Look at Tmux first, then Unix username.
This will be helpful when pair programming via Tmux and Vim.

Use env vars rather than other approaches that would require shelling
out; the other approaches can block I/O and cause the Vim cursor to
flicker. My approach is more performant.

This approach also requires using an odd-looking global function
declaration, which is necessary for interpolating in the scope of the
`vim.opt.statusline` string. This is good for performance but can cause
global naming conflicts. Therefore, I've chosen a hyper-specific and
wordy function name to avoid global naming conflicts:

```
function _G.tmux_user_or_unix_user_from_env_vars()
```
