### PR TITLE
laptop.sh: install mods for AI on the command line

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -115,6 +115,9 @@ if ! command -v godoc &> /dev/null; then
   go install golang.org/x/tools/cmd/godoc@latest
 fi
 
+# AI via CLI
+go install github.com/charmbracelet/mods@latest
+
 # Ruby
 v="3.4.1"
 if [ ! -d "$HOME/.rubies/ruby-$v" ]; then


### PR DESCRIPTION
Access LLMs such as GPT-4, Open AI o1-mini, Claude Sonnet 3.5,
etc. via API keys or by running Ollama.

From the command line, I can do, for example:

```bash
cat example.rb | mods "What does this code do?"
```

I'm interested in adding Vim key bindings for this in the future.

My only `mods --settings` changes from the default are:

```yaml
default-model: o1-mini
apis:
  openai:
    base-url: https://api.openai.com/v1
    api-key: redacted
    api-key-env: OPENAI_API_KEY
    models: # https://platform.openai.com/docs/models
      o1-mini:
        max-input-chars: 500000
        fallback: gpt-4o-mini
      gpt-4o-mini:
        max-input-chars: 392000
        fallback: gpt-4o
      gpt-4o:
        max-input-chars: 392000
```
