### PR TITLE
vim: simplify config

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -399,13 +399,7 @@ lspconfig.ts_ls.setup({
 })
 vim.g.markdown_fenced_languages = { "ts=typescript" }
 vim.api.nvim_create_autocmd("FileType", {
-	pattern = "typescript",
-	callback = function()
-		format_on_save("prettier --parser typescript %")
-	end,
-})
-vim.api.nvim_create_autocmd("FileType", {
-	pattern = "typescriptreact",
+  pattern = { "typescript", "typescriptreact" },
 	callback = function()
 		format_on_save("prettier --parser typescript %")
 	end,


### PR DESCRIPTION
- Use `vim.keymap.set` instead of deprecated `vim.api.nvim_set_keymap`
  for key mappings.
- Replace custom `buf_map` and `filetype_autocmd` functions with direct
  calls to `vim.keymap.set` and `vim.api.nvim_create_autocmd`.
- Simplify the `get_user` function by using `vim.fn.systemlist` instead
  of `io.popen`.
- Consolidate autocommand definitions using
  `vim.api.nvim_create_autocmd` directly with callbacks.
- Remove redundant options in key mapping and autocmd definitions by
  utilizing defaults and more concise syntax.
- Improve code readability and maintainability by leveraging Lua's
  features and Neovim's API enhancements.
