### PR TITLE
vim/ai: use goose instead of mods

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -120,6 +120,7 @@ go install golang.org/x/tools/cmd/goimports@latest
 go install golang.org/x/tools/gopls@latest
 
 # AI via CLI
+curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
 go install github.com/charmbracelet/mods@latest
 go install github.com/croaky/mdembed@latest
 

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -57,6 +57,9 @@ export BAT_THEME="TwoDark"
 # Go
 PATH="$HOME/go/bin:$PATH"
 
+# Goose
+PATH="$HOME/.local/bin:$PATH"
+
 # Ruby
 export BUNDLE_IGNORE_FUNDING_REQUESTS="true"
 export BUNDLE_IGNORE_MESSAGES="true"

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -166,6 +166,17 @@ local function run_file(key, cmd_template, split_cmd)
 	end, { buffer = 0 })
 end
 
+local function run_goose(goose_cmd)
+	local file_path = vim.fn.expand("%")
+	local embedded_text = vim.fn.system("cat " .. file_path .. " | mdembed")
+	vim.cmd("vsplit | terminal goose " .. goose_cmd)
+	vim.cmd("startinsert")
+	vim.schedule(function()
+		vim.api.nvim_chan_send(vim.b.terminal_job_id, embedded_text)
+		vim.api.nvim_chan_send(vim.b.terminal_job_id, "\r") -- press "Enter"
+	end)
+end
+
 function _G.get_user()
 	-- Try to get GitHub username
 	local github_user = vim.fn.systemlist("git config --get github.user")[1] or ""
@@ -224,6 +235,9 @@ local on_attach = function(_, bufnr)
 	map("n", "gn", vim.lsp.buf.rename, { buffer = bufnr })
 	map("n", "gr", vim.lsp.buf.references, { buffer = bufnr })
 end
+
+-- Terminal
+vim.api.nvim_set_keymap("t", "<Esc>", "<C-\\><C-n>", { noremap = true })
 
 -- Env
 vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
@@ -380,9 +394,18 @@ vim.api.nvim_create_autocmd("FileType", {
 		end, { buffer = 0 })
 
 		-- Run through LLM
-		run_file("<Leader>r", "cat % | mdembed | mods", "vsplit")
-		run_file("<Leader>c", "cat % | mdembed | mods -C", "vsplit")
+		map("n", "<Leader>r", function()
+			run_goose("session")
+		end, { buffer = 0 })
+		map("n", "<Leader>c", function()
+			run_goose("session --resume")
+		end, { buffer = 0 })
 	end,
+})
+
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+	pattern = ".goosehints",
+	command = "set filetype=markdown",
 })
 
 -- Ruby

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -166,15 +166,17 @@ local function run_file(key, cmd_template, split_cmd)
 	end, { buffer = 0 })
 end
 
-local function run_goose(goose_cmd)
-	local file_path = vim.fn.expand("%")
-	local embedded_text = vim.fn.system("cat " .. file_path .. " | mdembed")
-	vim.cmd("vsplit | terminal goose " .. goose_cmd)
-	vim.cmd("startinsert")
-	vim.schedule(function()
-		vim.api.nvim_chan_send(vim.b.terminal_job_id, embedded_text)
-		vim.api.nvim_chan_send(vim.b.terminal_job_id, "\r") -- press "Enter"
-	end)
+local function run_goose(key, goose_cmd)
+	map("n", key, function()
+		local file_path = vim.fn.expand("%")
+		local embedded_text = vim.fn.system("cat " .. file_path .. " | mdembed")
+		vim.cmd("vsplit | terminal goose " .. goose_cmd)
+		vim.cmd("startinsert")
+		vim.schedule(function()
+			vim.api.nvim_chan_send(vim.b.terminal_job_id, embedded_text)
+			vim.api.nvim_chan_send(vim.b.terminal_job_id, "\r") -- press "Enter"
+		end)
+	end, { buffer = 0 })
 end
 
 function _G.get_user()
@@ -394,12 +396,8 @@ vim.api.nvim_create_autocmd("FileType", {
 		end, { buffer = 0 })
 
 		-- Run through LLM
-		map("n", "<Leader>r", function()
-			run_goose("session")
-		end, { buffer = 0 })
-		map("n", "<Leader>c", function()
-			run_goose("session --resume")
-		end, { buffer = 0 })
+		run_goose("<Leader>r", "session")
+		run_goose("<Leader>c", "session --resume")
 	end,
 })
 


### PR DESCRIPTION
Goose has the ability to edit files, run tests, etc.
The term of art in the industry is to "use tools".

https://block.github.io/goose/

I like that Goose is open source, written in Rust, maintained by the
Block team, and built upon the Model Context Protocol. These feel like
solid foundations upon which to build our tools.

This change installs and configures Goose:

- Update laptop.sh to install the Goose CLI tool via curl.
- Append Goose installation directory to PATH in shell/zshrc.
- Extend Vim configuration with:
  - A new function (`run_goose`) to run Goose commands in a split terminal.
  - Key mappings (`<Leader>r` for starting a new session and `<Leader>c`
    for resuming) that leverage the Goose CLI.
  - An `Esc` key mapping easily exit terminal insert mode.
  - An `autocmd` to set the `filetype` for `.goosehints` files to Markdown.
