### PR TITLE
ai: use mods from vim, goose session from shell

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -166,19 +166,6 @@ local function run_file(key, cmd_template, split_cmd)
 	end, { buffer = 0 })
 end
 
-local function run_goose(key, goose_cmd)
-	map("n", key, function()
-		local file_path = vim.fn.expand("%")
-		local embedded_text = vim.fn.system("cat " .. file_path .. " | mdembed")
-		vim.cmd("vsplit | terminal goose " .. goose_cmd)
-		vim.cmd("startinsert")
-		vim.schedule(function()
-			vim.api.nvim_chan_send(vim.b.terminal_job_id, embedded_text)
-			vim.api.nvim_chan_send(vim.b.terminal_job_id, "\r") -- press "Enter"
-		end)
-	end, { buffer = 0 })
-end
-
 function _G.get_user()
 	-- Try to get GitHub username
 	local github_user = vim.fn.systemlist("git config --get github.user")[1] or ""
@@ -396,8 +383,8 @@ vim.api.nvim_create_autocmd("FileType", {
 		end, { buffer = 0 })
 
 		-- Run through LLM
-		run_goose("<Leader>r", "session")
-		run_goose("<Leader>c", "session --resume")
+		run_file("<Leader>r", "cat % | mdembed | mods", "vsplit")
+		run_file("<Leader>c", "cat % | mdembed | mods -C", "vsplit")
 	end,
 })
 


### PR DESCRIPTION
`mods` is easier to work with from within Vim.

The interactive `goose session` is too awkward.
Keep it installed so it's available from the shell
in case I want to have it apply certain changes.

Will continue to use `o1` from Vim/mods and `o3-mini`
from `goose session`.
