### PR TITLE
git: use histogram as diff algorithm

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -24,6 +24,7 @@
 [credential "https://gist.github.com"]
   helper = !/opt/homebrew/bin/gh auth git-credential
 [diff]
+  algorithm = histogram
   noprefix = true
   tool = vimdiff
 [fetch]


### PR DESCRIPTION
- Provides clearer diffs for moved code blocks.
- Improves upon `patience` diff with better chunk grouping.
- Recommended by Git experts over the default `myers`.
