### PR TITLE
git: enable rerere autoupdate for automatic conflict resolution

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -50,4 +50,5 @@
 [rebase]
   autosquash = true
 [rerere]
+  autoupdate = true
   enabled = true


### PR DESCRIPTION
- Applies known resolutions automatically during rebases.
- Reduces manual conflict resolution for repeated merges.
- No downside if unused, but helpful for frequent rebases.
