### PR TITLE
vim: use Ruby LSP

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -126,7 +126,11 @@ v="3.4.4"
 if [ ! -d "$HOME/.rubies/ruby-$v" ]; then
   RUBY_CONFIGURE_OPTS="--enable-yjit --with-openssl-dir=$(brew --prefix openssl@3)" ruby-build "$v" "$HOME/.rubies/ruby-$v"
 fi
-gem install ruby-lsp
+if gem list -i ruby-lsp; then
+  gem update ruby-lsp
+else
+  gem install ruby-lsp
+fi
 
 # NPM
 npm install -g npm@latest

--- a/laptop.sh
+++ b/laptop.sh
@@ -126,6 +126,7 @@ v="3.4.4"
 if [ ! -d "$HOME/.rubies/ruby-$v" ]; then
   RUBY_CONFIGURE_OPTS="--enable-yjit --with-openssl-dir=$(brew --prefix openssl@3)" ruby-build "$v" "$HOME/.rubies/ruby-$v"
 fi
+gem install ruby-lsp
 
 # NPM
 npm install -g npm@latest

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -376,10 +376,12 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Ruby
-lspconfig.solargraph.setup({
+lspconfig.ruby_lsp.setup({
 	capabilities = capabilities,
 	on_attach = on_attach,
-	settings = { solargraph = { diagnostics = false } },
+	init_options = {
+		formatter = "rubocop",
+	},
 })
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "ruby",


### PR DESCRIPTION
Ruby LSP seems to have surpassed Solargraph as the preferred LSP in the
Ruby community. It is well-maintained and well-funded by Shopify.

https://shopify.github.io/ruby-lsp/

- Switch Neovim’s LSP setup from `solargraph` to `ruby_lsp` and
  configure RuboCop as the formatter.
- Add a global installation of the `ruby-lsp` gem in `laptop.sh`.
