### PR TITLE
vim: rename .llm.md to AGENTS.md

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -381,7 +381,7 @@ vim.api.nvim_create_autocmd("FileType", {
 		end, { buffer = 0 })
 
 		-- Run through LLM
-		run_file("<Leader>r", pipefail("(cat %; [ -f .llm.md ] && cat .llm.md) | mdembed | mods"), "vsplit")
+		run_file("<Leader>r", pipefail("(cat %; [ -f AGENTS.md ] && cat AGENTS.md) | mdembed | mods"), "vsplit")
 		run_file("<Leader>c", pipefail("cat % | mdembed | mods -C"), "vsplit")
 	end,
 })


### PR DESCRIPTION
This may be more of an industry standard naming convention?

`AGENTS.md` can be picked up by OpenAI Codex CLI:

```
npm install -g @openai/codex
codex
```

https://github.com/openai/codex
