### PR TITLE
ssh: include private config file

### DIFF
--- a/shell/ssh
+++ b/shell/ssh
@@ -1,4 +1,5 @@
-Include ~/.ssh/config.private
+# Optionally include private config if it exists; SSH will ignore if missing
+Include ~/.ssh/config.private*
 
 Host *
   AddKeysToAgent yes


### PR DESCRIPTION
This allows users to keep sensitive SSH configurations separate
from the version-controlled config. Private configs can include
host-specific settings, jump hosts, custom key paths, or any
SSH configuration that shouldn't be shared in the public repo.

The private config file (~/.ssh/config.private) is loaded first,
allowing it to override or supplement the default settings.
