### PR TITLE
ruby: remove ruby-lsp

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -126,11 +126,6 @@ v="3.4.5"
 if [ ! -d "$HOME/.rubies/ruby-$v" ]; then
   RUBY_CONFIGURE_OPTS="--enable-yjit --with-openssl-dir=$(brew --prefix openssl@3)" ruby-build "$v" "$HOME/.rubies/ruby-$v"
 fi
-if gem list -i ruby-lsp; then
-  gem update ruby-lsp
-else
-  gem install ruby-lsp
-fi
 
 # NPM
 npm install -g npm@latest

--- a/vim/init.lua
+++ b/vim/init.lua
@@ -357,12 +357,6 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Ruby
-lspconfig.ruby_lsp.setup({
-	on_attach = on_attach,
-	init_options = {
-		formatter = "rubocop",
-	},
-})
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "ruby",
 	callback = function()


### PR DESCRIPTION
With autocomplete removed (replaced by GitHub Copilot),
I'm not using Ruby LSP for anything anymore.

Format-on-save is handled elsewhere by rubocop via conform.vim.
