### PR TITLE
vim: migrate to vim.lsp.config

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -42,7 +42,7 @@ require("lazy").setup({
 	-- Sensible defaults
 	"tpope/vim-sensible",
 
-	-- LSP Config
+	-- LSP server configurations (provides configs for vim.lsp.config)
 	{
 		"neovim/nvim-lspconfig",
 	},
@@ -176,8 +176,7 @@ map("n", "<C-k>", "<C-w>k")
 map("n", "<C-h>", "<C-w>h")
 map("n", "<C-l>", "<C-w>l")
 
--- LSPs
-local lspconfig = require("lspconfig")
+-- LSP Configuration
 local on_attach = function(_, bufnr)
 	map("n", "gd", vim.lsp.buf.definition, { buffer = bufnr })
 	map("n", "gh", vim.lsp.buf.hover, { buffer = bufnr })
@@ -236,9 +235,10 @@ vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
 })
 
 -- Bash
-lspconfig.bashls.setup({
+vim.lsp.config("bashls", {
 	on_attach = on_attach,
 })
+vim.lsp.enable("bashls")
 
 -- Gitcommit
 vim.api.nvim_create_autocmd("FileType", {
@@ -251,9 +251,10 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Go
-lspconfig.gopls.setup({
+vim.lsp.config("gopls", {
 	on_attach = on_attach,
 })
+vim.lsp.enable("gopls")
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "go",
 	callback = function()
@@ -286,9 +287,10 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- HTML
-lspconfig.html.setup({
+vim.lsp.config("html", {
 	on_attach = on_attach,
 })
+vim.lsp.enable("html")
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "html",
 	callback = function()
@@ -298,7 +300,7 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Lua
-lspconfig.lua_ls.setup({
+vim.lsp.config("lua_ls", {
 	on_attach = on_attach,
 	settings = {
 		Lua = {
@@ -314,6 +316,7 @@ lspconfig.lua_ls.setup({
 		},
 	},
 })
+vim.lsp.enable("lua_ls")
 vim.api.nvim_create_autocmd("FileType", {
 	pattern = "lua",
 	callback = function()
@@ -430,9 +433,10 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- TypeScript
-lspconfig.ts_ls.setup({
+vim.lsp.config("ts_ls", {
 	on_attach = on_attach,
 })
+vim.lsp.enable("ts_ls")
 vim.g.markdown_fenced_languages = { "ts=typescript" }
 
 -- Status line


### PR DESCRIPTION
From `:help`:

The "framework" part of nvim-lspconfig is DEPRECATED.
The "configs" are NOT deprecated, but were moved to the `lsp/` directory
so that `|vim.lsp.config()|` automatically finds them.

This means:

- `require'lspconfig'[…]` must NOT be used.
  Use `vim.lsp.config(…)` instead.
- The `require'lspconfig'` quasi-framework will be DELETED,
  and is not supported in Nvim 0.11+.
- The nvim-lspconfig configs (`|lspconfig-all|`) now live in `lsp/`
  instead of `lua/lspconfig/`.
- To use the configs, call `vim.lsp.config(…)` instead of
  `require'lspconfig'[…]`.

MIGRATION INSTRUCTIONS

To migrate:

- Upgrade to Nvim 0.11 or later.
- Change `require'lspconfig'[…]` to `vim.lsp.config(…)`.
  - Some field names changed, see `|lspconfig-vs-vim.lsp.config|`.
  - See `|lsp-config|` for details.

BACKGROUND

Since Nvim 0.11, nvim-lspconfig provides configs in its "lsp/"
directory. The old configs still exist in "lua/lspconfig/configs/" but
are deprecated and will be DELETED.

This means the "configs" role of nvim-lspconfig continues to be
relevant, but it is now a "data-only" repository instead of a
"framework". The only change needed from you, and from plugins, is to
use the Nvim 0.11 `vim.lsp.config` interface to setup LSP configs
instead of the old `require'lspconfig'` quasi-framework.
